### PR TITLE
T/16 ListCommand#isEnabled should be forced to false if selection is in graveyard.

### DIFF
--- a/src/indentcommand.js
+++ b/src/indentcommand.js
@@ -32,12 +32,8 @@ export default class IndentCommand extends Command {
 		 */
 		this._indentBy = indentDirection == 'forward' ? 1 : -1;
 
-		// Refresh command state after selection is changed or changes has been done to the document.
-		this.listenTo( editor.document.selection, 'change:range', () => {
-			this.refreshState();
-		} );
-
-		this.listenTo( editor.document, 'changesDone', () => {
+		// Refresh command state after selection is changed.
+		this.listenTo( editor.document.selection, 'change', () => {
 			this.refreshState();
 		} );
 	}

--- a/src/listcommand.js
+++ b/src/listcommand.js
@@ -187,6 +187,11 @@ export default class ListCommand extends Command {
 		}
 
 		const selection = this.editor.document.selection;
+
+		if ( selection.getFirstPosition().root.rootName == '$graveyard' ) {
+			return false;
+		}
+
 		const schema = this.editor.document.schema;
 		const position = getPositionBeforeBlock( selection.getFirstPosition(), schema );
 

--- a/src/listcommand.js
+++ b/src/listcommand.js
@@ -38,14 +38,11 @@ export default class ListCommand extends Command {
 		 */
 		this.set( 'value', false );
 
-		const changeCallback = () => {
+		// Listen on selection and document changes and set the current command's value.
+		this.listenTo( editor.document.selection, 'change', () => {
 			this.refreshValue();
 			this.refreshState();
-		};
-
-		// Listen on selection and document changes and set the current command's value.
-		this.listenTo( editor.document.selection, 'change:range', changeCallback );
-		this.listenTo( editor.document, 'changesDone', changeCallback );
+		} );
 	}
 
 	/**

--- a/tests/listcommand.js
+++ b/tests/listcommand.js
@@ -104,6 +104,11 @@ describe( 'ListCommand', () => {
 			doc.selection.collapse( doc.getRoot().getChild( 4 ) );
 			expect( command.isEnabled ).to.be.false;
 		} );
+
+		it( 'should be false if selection is in graveyard', () => {
+			doc.selection.collapse( doc.graveyard );
+			expect( command.isEnabled ).to.be.false;
+		} );
 	} );
 
 	describe( '_doExecute', () => {


### PR DESCRIPTION
ListCommand#isEnabled should be forced to false if selection is in graveyard.

Fixes ckeditor/ckeditor5#2949 
