### PR TITLE
Fixed: Stop using `move` converter.

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -109,46 +109,6 @@ export function modelViewRemove( evt, data, consumable, conversionApi ) {
 }
 
 /**
- * Model to view converter for `listItem` model element move.
- *
- * @see module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:move
- * @param {module:utils/eventinfo~EventInfo} evt Object containing information about the fired event.
- * @param {Object} data Additional information about the change.
- * @param {module:engine/conversion/modelconsumable~ModelConsumable} consumable Values to consume.
- * @param {Object} conversionApi Conversion interface.
- */
-export function modelViewMove( evt, data, consumable, conversionApi ) {
-	if ( !consumable.consume( data.item, 'move' ) ) {
-		return;
-	}
-
-	const viewItem = conversionApi.mapper.toViewElement( data.item );
-
-	// 1. Break the container after and before the list item.
-	// This will create a view list with one view list item -- the one that changed type.
-	viewWriter.breakContainer( ViewPosition.createBefore( viewItem ) );
-	viewWriter.breakContainer( ViewPosition.createAfter( viewItem ) );
-
-	// 2. Extract view list with changed view list item and merge "hole" possibly created by breaking and removing elements.
-	const viewList = viewItem.parent;
-	const viewListPrev = viewList.previousSibling;
-	const viewListNext = viewList.nextSibling;
-
-	let insertionPosition = conversionApi.mapper.toViewPosition( data.targetPosition );
-
-	if ( insertionPosition.parent.name == 'ol' || insertionPosition.parent.name == 'ul' ) {
-		insertionPosition = viewWriter.breakContainer( insertionPosition );
-	}
-
-	viewWriter.move( ViewRange.createOn( viewList ), insertionPosition );
-
-	// No worries, merging will happen only if both elements exist and they are same type of lists.
-	mergeViewLists( viewListPrev, viewListNext );
-	mergeViewLists( viewList, viewList.nextSibling );
-	mergeViewLists( viewList.previousSibling, viewList );
-}
-
-/**
  * Model to view converter for `indent` attribute change on `listItem` model element.
  *
  * @see module:engine/conversion/modelconversiondispatcher~ModelConversionDispatcher#event:changeAttribute

--- a/src/listengine.js
+++ b/src/listengine.js
@@ -17,7 +17,6 @@ import {
 	modelViewChangeType,
 	modelViewMergeAfter,
 	modelViewRemove,
-	modelViewMove,
 	modelViewSplitOnInsert,
 	modelViewChangeIndent,
 	viewModelConverter,
@@ -70,11 +69,6 @@ export default class ListEngine extends Plugin {
 		editing.modelToView.on( 'remove', modelViewMergeAfter, { priority: 'low' } );
 		data.modelToView.on( 'remove:listItem', modelViewRemove );
 		data.modelToView.on( 'remove', modelViewMergeAfter, { priority: 'low' } );
-
-		editing.modelToView.on( 'move:listItem', modelViewMove );
-		editing.modelToView.on( 'move', modelViewMergeAfter, { priority: 'low' } );
-		data.modelToView.on( 'move:listItem', modelViewMove );
-		data.modelToView.on( 'move', modelViewMergeAfter, { priority: 'low' } );
 
 		editing.modelToView.on( 'changeAttribute:indent:listItem', modelViewChangeIndent );
 		data.modelToView.on( 'changeAttribute:indent:listItem', modelViewChangeIndent );

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -462,18 +462,6 @@ describe( 'ListEngine', () => {
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<ul><li></li></ul>' );
 		} );
 
-		it( 'model move converter should not fire if change was already consumed', () => {
-			editor.editing.modelToView.on( 'move', ( evt, data, consumable ) => {
-				consumable.consume( data.item, 'move' );
-			}, { priority: 'highest' } );
-
-			setModelData( doc, '<listItem indent="0" type="bulleted"></listItem><paragraph>foo</paragraph>' );
-
-			doc.batch().move( root.getChild( 0 ), ModelPosition.createAt( root, 2 ) );
-
-			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<ul><li></li></ul><p>foo</p>' );
-		} );
-
 		it( 'model change type converter should not fire if change was already consumed', () => {
 			editor.editing.modelToView.on( 'changeAttribute:type', ( evt, data, consumable ) => {
 				consumable.consume( data.item, 'changeAttribute:type' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Stop using `ModelConversionDispatcher#event:move` for conversion.

---

### Additional information

This is caused by changes in `ckeditor5-engine`.