### PR TITLE
List feature patches.

### DIFF
--- a/src/indentcommand.js
+++ b/src/indentcommand.js
@@ -87,6 +87,11 @@ export default class IndentCommand extends Command {
 			}
 
 			// Check whether some of changed list items' type should not be fixed.
+			// But first, reverse `itemsToChange` again -- we always want to perform those fixes starting from first item (source-wise).
+			if ( this._indentBy < 0 ) {
+				itemsToChange = itemsToChange.reverse();
+			}
+
 			for ( let item of itemsToChange ) {
 				_fixType( item, batch );
 			}
@@ -114,8 +119,12 @@ export default class IndentCommand extends Command {
 			let prev = listItem.previousSibling;
 
 			while ( prev && prev.is( 'listItem' ) && prev.getAttribute( 'indent' ) >= indent ) {
-				if ( prev.getAttribute( 'indent' ) == indent && prev.getAttribute( 'type' ) == type ) {
-					return true;
+				if ( prev.getAttribute( 'indent' ) == indent ) {
+					// The item is on the same level.
+					// If it has same type, it means that we found a preceding sibling from the same list.
+					// If it does not have same type, it means that `listItem` is on different list (this can happen only
+					// on top level lists, though).
+					return prev.getAttribute( 'type' ) == type;
 				}
 
 				prev = prev.previousSibling;

--- a/src/indentcommand.js
+++ b/src/indentcommand.js
@@ -68,7 +68,7 @@ export default class IndentCommand extends Command {
 
 			// We need to be sure to keep model in correct state after each small change, because converters
 			// bases on that state and assumes that model is correct.
-			// Because of that, if the command outdented items, we will outdent them starting from the last item, as
+			// Because of that, if the command outdents items, we will outdent them starting from the last item, as
 			// it is safer.
 			if ( this._indentBy < 0 ) {
 				itemsToChange = itemsToChange.reverse();
@@ -87,8 +87,8 @@ export default class IndentCommand extends Command {
 				}
 				// If indent is >= 0, change the attribute value.
 				else {
-					// If indent is > 0 and the item was outdented, check whether list item's type should not be fixed.
-					if ( indent > 0 && this._indentBy < 0 ) {
+					// If indent is > 0 check whether list item's type should not be fixed.
+					if ( indent > 0 ) {
 						// First, find previous sibling with same indent.
 						let prev = item.previousSibling;
 

--- a/src/listcommand.js
+++ b/src/listcommand.js
@@ -42,14 +42,11 @@ export default class ListCommand extends Command {
 		 */
 		this.set( 'value', false );
 
-		const changeCallback = () => {
+		// Listen on selection and document changes and set the current command's value.
+		this.listenTo( editor.document, 'changesDone', () => {
 			this.refreshValue();
 			this.refreshState();
-		};
-
-		// Listen on selection and document changes and set the current command's value.
-		this.listenTo( editor.document.selection, 'change:range', changeCallback );
-		this.listenTo( editor.document, 'changesDone', changeCallback );
+		} );
 	}
 
 	/**
@@ -59,7 +56,7 @@ export default class ListCommand extends Command {
 		// Check whether closest `listItem` ancestor of the position has a correct type.
 		const listItem = first( this.editor.document.selection.getSelectedBlocks() );
 
-		this.value = listItem !== null && listItem.getAttribute( 'type' ) == this.type;
+		this.value = listItem && listItem.is( 'listItem' ) && listItem.getAttribute( 'type' ) == this.type;
 	}
 
 	/**
@@ -232,7 +229,7 @@ export default class ListCommand extends Command {
 	 * @inheritDoc
 	 */
 	_checkEnabled() {
-		// If command is enabled it means that we are in list item, so the command should be enabled.
+		// If command value is true it means that we are in list item, so the command should be enabled.
 		if ( this.value ) {
 			return true;
 		}

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -130,6 +130,29 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">g</listItem>'
 				);
 			} );
+
+			it( 'should fix list type when item is intended if needed', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem indent="2" type="numbered">c</listItem>' +
+					'<listItem indent="1" type="bulleted">d</listItem>'
+				);
+
+				doc.selection.setRanges( [ new Range(
+					new Position( root.getChild( 3 ), [ 0 ] )
+				) ] );
+
+				command._doExecute();
+
+				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem indent="2" type="numbered">c</listItem>' +
+					'<listItem indent="2" type="numbered">d</listItem>'
+				);
+			} );
 		} );
 	} );
 
@@ -234,7 +257,7 @@ describe( 'IndentCommand', () => {
 				);
 			} );
 
-			it( 'should fix list type if item is outdented', () => {
+			it( 'should fix list type when item is outdented if needed', () => {
 				setData(
 					doc,
 					'<listItem indent="0" type="bulleted">a</listItem>' +

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -384,7 +384,7 @@ describe( 'IndentCommand', () => {
 				);
 			} );
 
-			it( 'should not fix list type when not needed', () => {
+			it( 'should not fix nested list items\' type when not needed', () => {
 				// There was a bug that the nested sub-list changed it's type because for a while, it was on same indent
 				// level as the originally outdented element.
 				setData(

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -67,7 +67,7 @@ describe( 'IndentCommand', () => {
 				expect( command.isEnabled ).to.be.false;
 			} );
 
-			// #53.
+			// Reported in PR #53.
 			it( 'should be false if selection starts in first list item #2', () => {
 				setData(
 					doc,
@@ -76,6 +76,20 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">c</listItem>' +
 					'<listItem indent="1" type="bulleted">[]d</listItem>' +
 					'<listItem indent="2" type="bulleted">e</listItem>'
+				);
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			// Reported in PR #53.
+			it( 'should be false if selection starts in first list item #3', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem indent="0" type="numbered">c</listItem>' +
+					'<listItem indent="1" type="bulleted">d</listItem>' +
+					'<listItem indent="0" type="bulleted">[]e</listItem>'
 				);
 
 				expect( command.isEnabled ).to.be.false;
@@ -362,6 +376,26 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">b</listItem>' +
 					'<listItem indent="1" type="numbered">c</listItem>' +
 					'<listItem indent="1" type="numbered">d</listItem>'
+				);
+			} );
+
+			// Reported in #53.
+			it( 'should fix list type when item is outdented #3', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">[b</listItem>' +
+					'<listItem indent="1" type="numbered">c</listItem>' +
+					'<listItem indent="1" type="numbered">d]</listItem>'
+				);
+
+				command._doExecute();
+
+				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="0" type="bulleted">b</listItem>' +
+					'<listItem indent="0" type="bulleted">c</listItem>' +
+					'<listItem indent="0" type="bulleted">d</listItem>'
 				);
 			} );
 

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -67,6 +67,16 @@ describe( 'IndentCommand', () => {
 				expect( command.isEnabled ).to.be.false;
 			} );
 
+			it( 'should be false if selection starts in first list item of top level list with different type than previous list', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="0" type="numbered">[]b</listItem>'
+				);
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
 			it( 'should be false if selection starts in a list item that has bigger indent than it\'s previous sibling', () => {
 				doc.enqueueChanges( () => {
 					doc.selection.collapse( root.getChild( 2 ) );
@@ -144,7 +154,7 @@ describe( 'IndentCommand', () => {
 				);
 			} );
 
-			it( 'should fix list type when item is intended if needed', () => {
+			it( 'should fix list type when item is intended (if needed)', () => {
 				setData(
 					doc,
 					'<listItem indent="0" type="bulleted">a</listItem>' +
@@ -280,7 +290,7 @@ describe( 'IndentCommand', () => {
 				);
 			} );
 
-			it( 'should fix list type when item is outdented if needed', () => {
+			it( 'should fix list type when item is outdented (if needed)', () => {
 				setData(
 					doc,
 					'<listItem indent="0" type="bulleted">a</listItem>' +
@@ -294,6 +304,25 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">a</listItem>' +
 					'<listItem indent="1" type="bulleted">b</listItem>' +
 					'<listItem indent="1" type="bulleted">c</listItem>'
+				);
+			} );
+
+			it( 'should fix list type when item is outdented to top level (if needed)', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">[]b</listItem>' +
+					'<listItem indent="0" type="numbered">c</listItem>'
+				);
+
+				command._doExecute();
+
+				// Another possible behaviour would be that "b" list item becomes first list item of a top level
+				// numbered list (so it does not change it's type) but it seems less correct from UX standpoint.
+				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="0" type="bulleted">b</listItem>' +
+					'<listItem indent="0" type="numbered">c</listItem>'
 				);
 			} );
 		} );

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -67,6 +67,20 @@ describe( 'IndentCommand', () => {
 				expect( command.isEnabled ).to.be.false;
 			} );
 
+			// #53.
+			it( 'should be false if selection starts in first list item #2', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem indent="0" type="bulleted">c</listItem>' +
+					'<listItem indent="1" type="bulleted">[]d</listItem>' +
+					'<listItem indent="2" type="bulleted">e</listItem>'
+				);
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
 			it( 'should be false if selection starts in first list item of top level list with different type than previous list', () => {
 				setData(
 					doc,
@@ -154,7 +168,7 @@ describe( 'IndentCommand', () => {
 				);
 			} );
 
-			it( 'should fix list type when item is intended (if needed)', () => {
+			it( 'should fix list type when item is intended #1', () => {
 				setData(
 					doc,
 					'<listItem indent="0" type="bulleted">a</listItem>' +
@@ -170,6 +184,30 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="1" type="bulleted">b</listItem>' +
 					'<listItem indent="2" type="numbered">c</listItem>' +
 					'<listItem indent="2" type="numbered">d</listItem>'
+				);
+			} );
+
+			// Not only boundary list items has to be fixed, but also items in the middle of selection.
+			it( 'should fix list type when item is intended #2', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">b</listItem>' +
+					'<listItem indent="1" type="numbered">[c</listItem>' +
+					'<listItem indent="0" type="bulleted">d</listItem>' +
+					'<listItem indent="1" type="numbered">e]</listItem>' +
+					'<listItem indent="0" type="bulleted">f</listItem>'
+				);
+
+				command._doExecute();
+
+				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">b</listItem>' +
+					'<listItem indent="2" type="numbered">c</listItem>' +
+					'<listItem indent="1" type="numbered">d</listItem>' +
+					'<listItem indent="2" type="numbered">e</listItem>' +
+					'<listItem indent="0" type="bulleted">f</listItem>'
 				);
 			} );
 		} );
@@ -290,7 +328,7 @@ describe( 'IndentCommand', () => {
 				);
 			} );
 
-			it( 'should fix list type when item is outdented (if needed)', () => {
+			it( 'should fix list type when item is outdented #1', () => {
 				setData(
 					doc,
 					'<listItem indent="0" type="bulleted">a</listItem>' +
@@ -304,6 +342,26 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">a</listItem>' +
 					'<listItem indent="1" type="bulleted">b</listItem>' +
 					'<listItem indent="1" type="bulleted">c</listItem>'
+				);
+			} );
+
+			// Look at next siblings if, after outdenting, a list item is a first item in it's list (list item "c").
+			it( 'should fix list type when item is outdented #2', () => {
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">[]b</listItem>' +
+					'<listItem indent="2" type="bulleted">c</listItem>' +
+					'<listItem indent="1" type="numbered">d</listItem>'
+				);
+
+				command._doExecute();
+
+				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="0" type="bulleted">b</listItem>' +
+					'<listItem indent="1" type="numbered">c</listItem>' +
+					'<listItem indent="1" type="numbered">d</listItem>'
 				);
 			} );
 
@@ -323,6 +381,29 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">a</listItem>' +
 					'<listItem indent="0" type="bulleted">b</listItem>' +
 					'<listItem indent="0" type="numbered">c</listItem>'
+				);
+			} );
+
+			it( 'should not fix list type when not needed', () => {
+				// There was a bug that the nested sub-list changed it's type because for a while, it was on same indent
+				// level as the originally outdented element.
+				setData(
+					doc,
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">b</listItem>' +
+					'<listItem indent="1" type="numbered">[]c</listItem>' +
+					'<listItem indent="2" type="bulleted">d</listItem>' +
+					'<listItem indent="2" type="bulleted">e</listItem>'
+				);
+
+				command._doExecute();
+
+				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="numbered">b</listItem>' +
+					'<listItem indent="0" type="bulleted">c</listItem>' +
+					'<listItem indent="1" type="bulleted">d</listItem>' +
+					'<listItem indent="1" type="bulleted">e</listItem>'
 				);
 			} );
 		} );

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -52,19 +52,25 @@ describe( 'IndentCommand', () => {
 
 		describe( 'isEnabled', () => {
 			it( 'should be true if selection starts in list item', () => {
-				doc.selection.collapse( root.getChild( 5 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 5 ) );
+				} );
 
 				expect( command.isEnabled ).to.be.true;
 			} );
 
 			it( 'should be false if selection starts in first list item', () => {
-				doc.selection.collapse( root.getChild( 0 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 0 ) );
+				} );
 
 				expect( command.isEnabled ).to.be.false;
 			} );
 
 			it( 'should be false if selection starts in a list item that has bigger indent than it\'s previous sibling', () => {
-				doc.selection.collapse( root.getChild( 2 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 2 ) );
+				} );
 
 				expect( command.isEnabled ).to.be.false;
 			} );
@@ -73,6 +79,7 @@ describe( 'IndentCommand', () => {
 			// and before we fixed it the command was enabled in such a case.
 			it( 'should be false if selection starts in a paragraph with indent attribute', () => {
 				doc.schema.allow( { name: 'paragraph', attributes: [ 'indent' ], inside: '$root' } );
+
 				setData( doc, '<listItem indent="0">a</listItem><paragraph indent="0">b[]</paragraph>' );
 
 				expect( command.isEnabled ).to.be.false;
@@ -81,7 +88,9 @@ describe( 'IndentCommand', () => {
 
 		describe( '_doExecute', () => {
 			it( 'should increment indent attribute by 1', () => {
-				doc.selection.collapse( root.getChild( 5 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 5 ) );
+				} );
 
 				command._doExecute();
 
@@ -97,7 +106,9 @@ describe( 'IndentCommand', () => {
 			} );
 
 			it( 'should increment indent of all sub-items of indented item', () => {
-				doc.selection.collapse( root.getChild( 1 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 1 ) );
+				} );
 
 				command._doExecute();
 
@@ -113,10 +124,12 @@ describe( 'IndentCommand', () => {
 			} );
 
 			it( 'should increment indent of all selected item when multiple items are selected', () => {
-				doc.selection.setRanges( [ new Range(
-					new Position( root.getChild( 1 ), [ 0 ] ),
-					new Position( root.getChild( 3 ), [ 0 ] )
-				) ] );
+				doc.enqueueChanges( () => {
+					doc.selection.setRanges( [ new Range(
+						new Position( root.getChild( 1 ), [ 0 ] ),
+						new Position( root.getChild( 3 ), [ 0 ] )
+					) ] );
+				} );
 
 				command._doExecute();
 
@@ -137,12 +150,8 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">a</listItem>' +
 					'<listItem indent="1" type="bulleted">b</listItem>' +
 					'<listItem indent="2" type="numbered">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>'
+					'<listItem indent="1" type="bulleted">[]d</listItem>'
 				);
-
-				doc.selection.setRanges( [ new Range(
-					new Position( root.getChild( 3 ), [ 0 ] )
-				) ] );
 
 				command._doExecute();
 
@@ -169,21 +178,27 @@ describe( 'IndentCommand', () => {
 
 		describe( 'isEnabled', () => {
 			it( 'should be true if selection starts in list item', () => {
-				doc.selection.collapse( root.getChild( 5 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 5 ) );
+				} );
 
 				expect( command.isEnabled ).to.be.true;
 			} );
 
 			it( 'should be true if selection starts in first list item', () => {
 				// This is in contrary to forward indent command.
-				doc.selection.collapse( root.getChild( 0 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 0 ) );
+				} );
 
 				expect( command.isEnabled ).to.be.true;
 			} );
 
 			it( 'should be true if selection starts in a list item that has bigger indent than it\'s previous sibling', () => {
 				// This is in contrary to forward indent command.
-				doc.selection.collapse( root.getChild( 2 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 2 ) );
+				} );
 
 				expect( command.isEnabled ).to.be.true;
 			} );
@@ -191,7 +206,9 @@ describe( 'IndentCommand', () => {
 
 		describe( '_doExecute', () => {
 			it( 'should decrement indent attribute by 1 (if it is bigger than 0)', () => {
-				doc.selection.collapse( root.getChild( 5 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 5 ) );
+				} );
 
 				command._doExecute();
 
@@ -207,7 +224,9 @@ describe( 'IndentCommand', () => {
 			} );
 
 			it( 'should rename listItem to paragraph (if indent is equal to 0)', () => {
-				doc.selection.collapse( root.getChild( 0 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 0 ) );
+				} );
 
 				command._doExecute();
 
@@ -223,7 +242,9 @@ describe( 'IndentCommand', () => {
 			} );
 
 			it( 'should decrement indent of all sub-items of outdented item', () => {
-				doc.selection.collapse( root.getChild( 1 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( root.getChild( 1 ) );
+				} );
 
 				command._doExecute();
 
@@ -239,10 +260,12 @@ describe( 'IndentCommand', () => {
 			} );
 
 			it( 'should outdent all selected item when multiple items are selected', () => {
-				doc.selection.setRanges( [ new Range(
-					new Position( root.getChild( 1 ), [ 0 ] ),
-					new Position( root.getChild( 3 ), [ 0 ] )
-				) ] );
+				doc.enqueueChanges( () => {
+					doc.selection.setRanges( [ new Range(
+						new Position( root.getChild( 1 ), [ 0 ] ),
+						new Position( root.getChild( 3 ), [ 0 ] )
+					) ] );
+				} );
 
 				command._doExecute();
 
@@ -262,12 +285,8 @@ describe( 'IndentCommand', () => {
 					doc,
 					'<listItem indent="0" type="bulleted">a</listItem>' +
 					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="numbered">c</listItem>'
+					'<listItem indent="2" type="numbered">[]c</listItem>'
 				);
-
-				doc.selection.setRanges( [ new Range(
-					new Position( root.getChild( 2 ), [ 0 ] )
-				) ] );
 
 				command._doExecute();
 
@@ -275,25 +294,6 @@ describe( 'IndentCommand', () => {
 					'<listItem indent="0" type="bulleted">a</listItem>' +
 					'<listItem indent="1" type="bulleted">b</listItem>' +
 					'<listItem indent="1" type="bulleted">c</listItem>'
-				);
-			} );
-
-			it( 'should not fix list type if item is outdented to top level', () => {
-				setData(
-					doc,
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="numbered">b</listItem>'
-				);
-
-				doc.selection.setRanges( [ new Range(
-					new Position( root.getChild( 1 ), [ 0 ] )
-				) ] );
-
-				command._doExecute();
-
-				expect( getData( doc, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="numbered">b</listItem>'
 				);
 			} );
 		} );

--- a/tests/list.js
+++ b/tests/list.js
@@ -5,15 +5,17 @@
 
 /* globals document */
 
-import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import List from '../src/list';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ListEngine from '../src/listengine';
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'List', () => {
-	let editor, bulletedListButton, numberedListButton, schema;
+	let editor, doc, bulletedListButton, numberedListButton, schema;
 
 	beforeEach( () => {
 		const editorElement = document.createElement( 'div' );
@@ -25,6 +27,7 @@ describe( 'List', () => {
 			.then( newEditor => {
 				editor = newEditor;
 				schema = editor.document.schema;
+				doc = editor.document;
 
 				bulletedListButton = editor.ui.componentFactory.create( 'bulletedList' );
 				numberedListButton = editor.ui.componentFactory.create( 'numberedList' );
@@ -59,9 +62,7 @@ describe( 'List', () => {
 	} );
 
 	it( 'should bind bulleted list button model to bulledList command', () => {
-		editor.setData( '<ul><li>foo</li></ul>' );
-		// Collapsing selection in model, which has just flat listItems.
-		editor.document.selection.collapse( editor.document.getRoot().getChild( 0 ) );
+		setData( doc, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
 
 		const command = editor.commands.get( 'bulletedList' );
 
@@ -76,9 +77,7 @@ describe( 'List', () => {
 	} );
 
 	it( 'should bind numbered list button model to numberedList command', () => {
-		editor.setData( '<ul><li>foo</li></ul>' );
-		// Collapsing selection in model, which has just flat listItems.
-		editor.document.selection.collapse( editor.document.getRoot().getChild( 0 ) );
+		setData( doc, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
 
 		const command = editor.commands.get( 'numberedList' );
 
@@ -99,9 +98,7 @@ describe( 'List', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			editor.setData( '<ul><li></li></ul>' );
-			// Collapsing selection in model, which has just flat listItems.
-			editor.document.selection.collapse( editor.document.getRoot().getChild( 0 ) );
+			setData( doc, '<listItem type="bulleted" indent="0">[]</listItem>' );
 
 			editor.editing.view.fire( 'enter', domEvtDataStub );
 
@@ -114,9 +111,7 @@ describe( 'List', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			editor.setData( '<ul><li>foobar</li></ul>' );
-			// Collapsing selection in model, which has just flat listItems.
-			editor.document.selection.collapse( editor.document.getRoot().getChild( 0 ) );
+			setData( doc, '<listItem type="bulleted" indent="0">foo[]</listItem>' );
 
 			editor.editing.view.fire( 'enter', domEvtDataStub );
 
@@ -141,9 +136,11 @@ describe( 'List', () => {
 		} );
 
 		it( 'should execute indentList command on tab key', () => {
-			editor.setData( '<ul><li>foo</li><li>bar</li></ul>' );
-			// Collapsing selection in model, which has just flat listItems.
-			editor.document.selection.collapse( editor.document.getRoot().getChild( 1 ) );
+			setData(
+				doc,
+				'<listItem type="bulleted" indent="0">foo</listItem>' +
+				'<listItem type="bulleted" indent="0">[]bar</listItem>'
+			);
 
 			editor.editing.view.fire( 'keydown', domEvtDataStub );
 
@@ -154,9 +151,11 @@ describe( 'List', () => {
 		it( 'should execute outdentList command on Shift+Tab keystroke', () => {
 			domEvtDataStub.keystroke += getCode( 'Shift' );
 
-			editor.setData( '<ul><li>foo<ul><li>bar</li></ul></li></ul>' );
-			// Collapsing selection in model, which has just flat listItems.
-			editor.document.selection.collapse( editor.document.getRoot().getChild( 1 ) );
+			setData(
+				doc,
+				'<listItem type="bulleted" indent="0">foo</listItem>' +
+				'<listItem type="bulleted" indent="1">[]bar</listItem>'
+			);
 
 			editor.editing.view.fire( 'keydown', domEvtDataStub );
 
@@ -165,9 +164,7 @@ describe( 'List', () => {
 		} );
 
 		it( 'should not indent if command is disabled', () => {
-			editor.setData( '<ul><li>foo</li></ul>' );
-			// Collapsing selection in model, which has just flat listItems.
-			editor.document.selection.collapse( editor.document.getRoot().getChild( 0 ) );
+			setData( doc, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
 
 			editor.editing.view.fire( 'keydown', domEvtDataStub );
 
@@ -177,9 +174,11 @@ describe( 'List', () => {
 		it( 'should not indent or outdent if alt+tab is pressed', () => {
 			domEvtDataStub.keystroke += getCode( 'alt' );
 
-			editor.setData( '<ul><li>foo</li></ul>' );
-			// Collapsing selection in model, which has just flat listItems.
-			editor.document.selection.collapse( editor.document.getRoot().getChild( 0 ) );
+			setData(
+				doc,
+				'<listItem type="bulleted" indent="0">foo</listItem>' +
+				'<listItem type="bulleted" indent="0">[]bar</listItem>'
+			);
 
 			editor.editing.view.fire( 'keydown', domEvtDataStub );
 

--- a/tests/listcommand.js
+++ b/tests/listcommand.js
@@ -62,35 +62,31 @@ describe( 'ListCommand', () => {
 
 		describe( 'value', () => {
 			it( 'should be false if first position in selection is not in a list item', () => {
-				doc.selection.collapse( doc.getRoot().getChild( 3 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( doc.getRoot().getChild( 3 ) );
+				} );
+
 				expect( command.value ).to.be.false;
 			} );
 
 			it( 'should be false if first position in selection is in a list item of different type', () => {
-				doc.selection.collapse( doc.getRoot().getChild( 2 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( doc.getRoot().getChild( 2 ) );
+				} );
+
 				expect( command.value ).to.be.false;
 			} );
 
 			it( 'should be true if first position in selection is in a list item of same type', () => {
-				doc.selection.collapse( doc.getRoot().getChild( 1 ) );
+				doc.enqueueChanges( () => {
+					doc.selection.collapse( doc.getRoot().getChild( 1 ) );
+				} );
+
 				expect( command.value ).to.be.true;
 			} );
 		} );
 
 		describe( 'isEnabled', () => {
-			it( 'should be true if command value is true', () => {
-				command.value = true;
-				command.refreshState();
-
-				expect( command.isEnabled ).to.be.true;
-
-				command.value = false;
-				doc.selection.collapse( doc.getRoot().getChild( 1 ) );
-
-				expect( command.value ).to.be.true;
-				expect( command.isEnabled ).to.be.true;
-			} );
-
 			it( 'should be true if entire selection is in a list', () => {
 				setData( doc, '<listItem type="bulleted" indent="0">[a]</listItem>' );
 				expect( command.isEnabled ).to.be.true;
@@ -252,10 +248,12 @@ describe( 'ListCommand', () => {
 				it( 'should rename closest block to listItem and set correct attributes', () => {
 					// From first paragraph to second paragraph.
 					// Command value=false, we are turning on list items.
-					doc.selection.setRanges( [ new Range(
-						Position.createAt( root.getChild( 2 ) ),
-						Position.createAt( root.getChild( 3 ) )
-					) ] );
+					doc.enqueueChanges( () => {
+						doc.selection.setRanges( [ new Range(
+							Position.createAt( root.getChild( 2 ) ),
+							Position.createAt( root.getChild( 3 ) )
+						) ] );
+					} );
 
 					command._doExecute();
 
@@ -275,10 +273,12 @@ describe( 'ListCommand', () => {
 				it( 'should rename closest listItem to paragraph', () => {
 					// From second bullet list item to first numbered list item.
 					// Command value=true, we are turning off list items.
-					doc.selection.setRanges( [ new Range(
-						Position.createAt( root.getChild( 1 ) ),
-						Position.createAt( root.getChild( 4 ) )
-					) ] );
+					doc.enqueueChanges( () => {
+						doc.selection.setRanges( [ new Range(
+							Position.createAt( root.getChild( 1 ) ),
+							Position.createAt( root.getChild( 4 ) )
+						) ] );
+					} );
 
 					// Convert paragraphs, leave numbered list items.
 					command._doExecute();
@@ -298,10 +298,12 @@ describe( 'ListCommand', () => {
 
 				it( 'should change closest listItem\'s type', () => {
 					// From first numbered lsit item to third bulleted list item.
-					doc.selection.setRanges( [ new Range(
-						Position.createAt( root.getChild( 4 ) ),
-						Position.createAt( root.getChild( 6 ) )
-					) ] );
+					doc.enqueueChanges( () => {
+						doc.selection.setRanges( [ new Range(
+							Position.createAt( root.getChild( 4 ) ),
+							Position.createAt( root.getChild( 6 ) )
+						) ] );
+					} );
 
 					// Convert paragraphs, leave numbered list items.
 					command._doExecute();
@@ -320,11 +322,13 @@ describe( 'ListCommand', () => {
 				} );
 
 				it( 'should handle outdenting sub-items when list item is turned off', () => {
-					// From first numbered lsit item to third bulleted list item.
-					doc.selection.setRanges( [ new Range(
-						Position.createAt( root.getChild( 1 ) ),
-						Position.createAt( root.getChild( 5 ) )
-					) ] );
+					// From first numbered list item to third bulleted list item.
+					doc.enqueueChanges( () => {
+						doc.selection.setRanges( [ new Range(
+							Position.createAt( root.getChild( 1 ) ),
+							Position.createAt( root.getChild( 5 ) )
+						) ] );
+					} );
 
 					// Convert paragraphs, leave numbered list items.
 					command._doExecute();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improvements to List feature:
* commands listen only to `model.Document#event:changesDone`,
* list item type fixing when item is indented/outdented is improved,
* removed possibility to indent first list item of a list, if that list was top level list of different type.

Closes ckeditor/ckeditor5#2975. Closes ckeditor/ckeditor5#2977. Closes ckeditor/ckeditor5#2980.