### PR TITLE
T/56 Adjust pasted lists indentation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^0.8.0",
+    "@ckeditor/ckeditor5-clipboard": "^0.5.0",
     "@ckeditor/ckeditor5-dev-lint": "^2.0.2",
     "@ckeditor/ckeditor5-editor-classic": "^0.7.2",
     "@ckeditor/ckeditor5-enter": "^0.9.0",

--- a/src/converters.js
+++ b/src/converters.js
@@ -46,7 +46,10 @@ export function modelViewInsertion( evt, data, consumable, conversionApi ) {
 	const modelItem = data.item;
 	const viewItem = generateLiInUl( modelItem, conversionApi.mapper );
 
-	injectViewList( modelItem, viewItem, conversionApi.mapper );
+	// Providing kind of "default" insert position in case of converting incorrect model.
+	const insertPosition = conversionApi.mapper.toViewPosition( ModelPosition.createBefore( modelItem ) );
+
+	injectViewList( modelItem, viewItem, conversionApi.mapper, insertPosition );
 }
 
 /**
@@ -689,6 +692,66 @@ function _fixItemsType( changePosition, fixPrevious, document, batch ) {
 			item = item[ fixPrevious ? 'previousSibling' : 'nextSibling' ];
 		}
 	} );
+}
+
+/**
+ * Fixer for pasted content that includes list items.
+ *
+ * Fixes indent of pasted list items so the pasted items match correctly to the context they are pasted into.
+ *
+ * Example:
+ *
+ *		<listItem type="bulleted" indent=0>A</listItem>
+ *		<listItem type="bulleted" indent=1>B^</listItem>
+ *		// At ^ paste:  <listItem type="bulleted" indent=4>X</listItem>
+ *		//              <listItem type="bulleted" indent=5>Y</listItem>
+ *		<listItem type="bulleted" indent=2>C</listItem>
+ *
+ * Should become:
+ *
+ *		<listItem type="bulleted" indent=0>A</listItem>
+ *		<listItem type="bulleted" indent=1>BX</listItem>
+ *		<listItem type="bulleted" indent=2>Y/listItem>
+ *		<listItem type="bulleted" indent=2>C</listItem>
+ *
+ * @param {module:engine/model/document~Document} document Document to observe.
+ * @returns {Function} Callback to be attached to {@link module:engine/model/document~Document#event:change document change event}.
+ */
+export function modelIndentPasteFixer( evt, data ) {
+	// Check whether inserted content starts from a `listItem`. If it does not, it means that there are some other
+	// elements before it and there is no need to fix indents, because even if we insert that content into a list,
+	// that list will be broken.
+	let item = data.content.getChild( 0 );
+
+	if ( item.is( 'listItem' ) ) {
+		// Get a reference list item. Inserted list items will be fixed according to that item.
+		const pos = data.selection.getFirstPosition();
+		let refItem = null;
+
+		if ( pos.parent.is( 'listItem' ) ) {
+			refItem = pos.parent;
+		} else if ( pos.nodeBefore && pos.nodeBefore.is( 'listItem' ) ) {
+			refItem = pos.nodeBefore;
+		}
+
+		// If there is `refItem` it means that we do insert list items into an existing list.
+		if ( refItem ) {
+			// First list item in `data` has indent equal to 0 (it is a first list item). It should have indent equal
+			// to the indent of reference item. We have to fix the first item and all of it's children and following siblings.
+			// Indent of all those items has to be adjusted to reference item.
+			const indentChange = refItem.getAttribute( 'indent' );
+
+			// Fix only if there is anything to fix.
+			if ( indentChange > 0 ) {
+				// Adjust indent of all "first" list items in inserted data.
+				while ( item && item.is( 'listItem' ) ) {
+					item.setAttribute( 'indent', item.getAttribute( 'indent' ) + indentChange );
+
+					item = item.nextSibling;
+				}
+			}
+		}
+	}
 }
 
 // Helper function that creates a `<ul><li></li></ul>` or (`<ol>`) structure out of given `modelItem` model `listItem` element.

--- a/src/listengine.js
+++ b/src/listengine.js
@@ -23,6 +23,7 @@ import {
 	modelViewSplitOnInsert,
 	modelViewChangeIndent,
 	modelChangePostFixer,
+	modelIndentPasteFixer,
 	viewModelConverter,
 	modelToViewPosition,
 	viewToModelPosition
@@ -108,6 +109,9 @@ export default class ListEngine extends Plugin {
 		data.viewToModel.on( 'element:ol', cleanList, { priority: 'high' } );
 		data.viewToModel.on( 'element:li', cleanListItem, { priority: 'high' } );
 		data.viewToModel.on( 'element:li', viewModelConverter );
+
+		// Fix indentation of pasted items.
+		data.on( 'insertContent', modelIndentPasteFixer, { priority: 'high' } );
 
 		// Register commands for numbered and bulleted list.
 		editor.commands.set( 'numberedList', new ListCommand( editor, 'numbered' ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Pasted list items' indentation now will be correctly adjusted if list items are pasted into a nested list. Closes ckeditor/ckeditor5#2978.