### PR TITLE
List view-to-model converter should return model.DocumentFragment instead of Array.

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -9,6 +9,7 @@
 
 import ViewListItemElement from './viewlistitemelement';
 
+import ModelDocumentFragment from '@ckeditor/ckeditor5-engine/src/model/documentfragment';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
 import modelWriter from '@ckeditor/ckeditor5-engine/src/model/writer';
@@ -366,7 +367,8 @@ export function viewModelConverter( evt, data, consumable, conversionApi ) {
 		data.indent++;
 
 		// `listItem`s will be kept in flat structure.
-		let items = [ listItem ];
+		let items = new ModelDocumentFragment();
+		items.appendChildren( listItem );
 
 		// Check all children of the converted `<li>`.
 		// At this point we assume there are no "whitespace" view text nodes in view list, between view list items.
@@ -378,7 +380,7 @@ export function viewModelConverter( evt, data, consumable, conversionApi ) {
 			// If this is a view list element, we will convert it and concat the result (`listItem` model elements)
 			// with already gathered results (in `items` array). `converted` should be a `ModelDocumentFragment`.
 			if ( child.name == 'ul' || child.name == 'ol' ) {
-				items = items.concat( Array.from( converted.getChildren() ) );
+				items.appendChildren( Array.from( converted.getChildren() ) );
 			}
 			// If it was not a list it was a "regular" list item content. Just append it to `listItem`.
 			else {

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -6,6 +6,7 @@
 import ListEngine from '../src/listengine';
 import ListCommand from '../src/listcommand';
 
+import ModelDocumentFragment from '@ckeditor/ckeditor5-engine/src/model/documentfragment';
 import ModelPosition from '@ckeditor/ckeditor5-engine/src/model/position';
 import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
 
@@ -3204,6 +3205,14 @@ describe( 'ListEngine', () => {
 			editor.setData( '<ul><li></li></ul>' );
 
 			expect( getModelData( modelDoc, { withoutSelection: true } ) ).to.equal( '' );
+		} );
+
+		it( 'view converter should pass model document fragment in data.output', () => {
+			editor.data.viewToModel.on( 'element:ul', ( evt, data ) => {
+				expect( data.output ).to.be.instanceof( ModelDocumentFragment );
+			}, { priority: 'lowest' } );
+
+			editor.setData( '<ul><li>Foo</li><li>Bar</li></ul>' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: List view-to-model converter now returns `model.DocumentFragment` containing `listItem` model elements, instead of `Array`. Closes ckeditor/ckeditor5#2983.