### PR TITLE
Fixed: Postfixer should not trigger for transparent batches.

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -570,6 +570,10 @@ export function viewToModelPosition( evt, data ) {
  */
 export function modelChangePostFixer( document ) {
 	return ( evt, type, changes, batch ) => {
+		if ( batch.type == 'transparent' ) {
+			return;
+		}
+
 		if ( type == 'remove' ) {
 			// Fix list items after the cut-out range.
 			// This fix is needed if items in model after cut-out range have now wrong indents compared to their previous siblings.

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -2638,6 +2638,29 @@ describe( 'ListEngine', () => {
 	} );
 
 	describe( 'post fixer', () => {
+		it( 'should not trigger if change-to-fix is in transparent batch', () => {
+			// Note that the same example is also tested below in insert suite, however in non-transparent batch.
+			const input =
+				'<listItem indent="0" type="bulleted">a</listItem>' +
+				'[]' +
+				'<listItem indent="1" type="bulleted">b</listItem>';
+
+			const inserted = '<paragraph>x</paragraph>';
+
+			const output =
+				'<listItem indent="0" type="bulleted">a</listItem>' +
+				'<paragraph>x</paragraph>' +
+				'<listItem indent="1" type="bulleted">b</listItem>';
+
+			setModelData( modelDoc, input );
+
+			modelDoc.enqueueChanges( () => {
+				modelDoc.batch( 'transparent' ).insert( modelDoc.selection.getFirstPosition(), parseModel( inserted, modelDoc.schema ) );
+			} );
+
+			expect( getModelData( modelDoc, { withoutSelection: true } ) ).to.equal( output );
+		} );
+
 		describe( 'insert', () => {
 			function test( testName, input, inserted, output ) {
 				it( testName, () => {

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -2638,8 +2638,8 @@ describe( 'ListEngine', () => {
 	} );
 
 	describe( 'post fixer', () => {
-		it( 'should not trigger if change-to-fix is in transparent batch', () => {
-			// Note that the same example is also tested below in insert suite, however in non-transparent batch.
+		it( 'should not be triggered if change-to-fix is in a transparent batch', () => {
+			// Note that the same example is also tested below in the insert suite, however in a non-transparent batch.
 			const input =
 				'<listItem indent="0" type="bulleted">a</listItem>' +
 				'[]' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: List model fixer will not trigger if change-to-fix is in `transparent` batch. Closes ckeditor/ckeditor5#2986.