### PR TITLE
Fixed: `view.UIElement` should be properly handled in list remove converter

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -102,8 +102,10 @@ export function modelViewRemove( evt, data, consumable, conversionApi ) {
 		return;
 	}
 
-	const viewPosition = conversionApi.mapper.toViewPosition( data.sourcePosition );
-	const viewItem = viewPosition.nodeAfter.is( 'li' ) ? viewPosition.nodeAfter : viewPosition.nodeAfter.getChild( 0 );
+	let viewPosition = conversionApi.mapper.toViewPosition( data.sourcePosition );
+	viewPosition = viewPosition.getLastMatchingPosition( value => !value.item.is( 'li' ) );
+
+	const viewItem = viewPosition.nodeAfter;
 
 	// 1. Break the container after and before the list item.
 	// This will create a view list with one view list item -- the one that changed type.

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -3347,10 +3347,13 @@ describe( 'ListEngine', () => {
 		} );
 
 		describe( 'remove converter should properly handle ui elements', () => {
-			let uiElement;
+			let uiElement, liFoo, liBar;
 
 			beforeEach( () => {
 				editor.setData( '<ul><li>Foo</li><li>Bar</li></ul>' );
+				liFoo = modelRoot.getChild( 0 );
+				liBar = modelRoot.getChild( 1 );
+
 				uiElement = new ViewUIElement( 'span' );
 			} );
 
@@ -3358,7 +3361,7 @@ describe( 'ListEngine', () => {
 				// Append ui element before <ul>.
 				viewRoot.insertChildren( 0, [ uiElement ] );
 
-				modelDoc.batch().remove( modelRoot.getChild( 0 ) );
+				modelDoc.batch().remove( liFoo );
 
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 					.to.equal( '<span></span><ul><li>Bar</li></ul>' );
@@ -3368,7 +3371,7 @@ describe( 'ListEngine', () => {
 				// Append ui element before <ul>.
 				viewRoot.getChild( 0 ).insertChildren( 0, [ uiElement ] );
 
-				modelDoc.batch().remove( modelRoot.getChild( 0 ) );
+				modelDoc.batch().remove( liFoo );
 
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 					.to.equal( '<ul><span></span><li>Bar</li></ul>' );
@@ -3378,7 +3381,7 @@ describe( 'ListEngine', () => {
 				// Append ui element before <ul>.
 				viewRoot.getChild( 0 ).insertChildren( 1, [ uiElement ] );
 
-				modelDoc.batch().remove( modelRoot.getChild( 1 ) );
+				modelDoc.batch().remove( liBar );
 
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 					.to.equal( '<ul><li>Foo</li><span></span></ul>' );

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -3345,6 +3345,45 @@ describe( 'ListEngine', () => {
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 				.to.equal( '<ul><li>Foo<span></span><ul><li>Xxx</li><li>Yyy</li></ul></li></ul>' );
 		} );
+
+		describe( 'remove converter should properly handle ui elements', () => {
+			let uiElement;
+
+			beforeEach( () => {
+				editor.setData( '<ul><li>Foo</li><li>Bar</li></ul>' );
+				uiElement = new ViewUIElement( 'span' );
+			} );
+
+			it( 'ui element before <ul>', () => {
+				// Append ui element before <ul>.
+				viewRoot.insertChildren( 0, [ uiElement ] );
+
+				modelDoc.batch().remove( modelRoot.getChild( 0 ) );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
+					.to.equal( '<span></span><ul><li>Bar</li></ul>' );
+			} );
+
+			it( 'ui element before first <li>', () => {
+				// Append ui element before <ul>.
+				viewRoot.getChild( 0 ).insertChildren( 0, [ uiElement ] );
+
+				modelDoc.batch().remove( modelRoot.getChild( 0 ) );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
+					.to.equal( '<ul><span></span><li>Bar</li></ul>' );
+			} );
+
+			it( 'ui element in the middle of list', () => {
+				// Append ui element before <ul>.
+				viewRoot.getChild( 0 ).insertChildren( 1, [ uiElement ] );
+
+				modelDoc.batch().remove( modelRoot.getChild( 1 ) );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
+					.to.equal( '<ul><li>Foo</li><span></span></ul>' );
+			} );
+		} );
 	} );
 
 	function getViewPosition( root, path ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `view.UIElement` will no longer be incorrectly removed instead of `<li>` element if it was before `<li>` element to remove. Closes ckeditor/ckeditor5#2991.