### PR TITLE
t/ckeditor5/447: List feature should use EditingKeystrokeHandler instead of direct event listeners

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -13,7 +13,6 @@ import numberedListIcon from '../theme/icons/numberedlist.svg';
 import bulletedListIcon from '../theme/icons/bulletedlist.svg';
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import { parseKeystroke } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 
 /**
@@ -62,29 +61,20 @@ export default class List extends Plugin {
 			}
 		} );
 
-		// Add Tab key support.
-		// When in list item, pressing Tab should indent list item, if possible.
-		// Pressing Shift+Tab should outdent list item.
-		this.listenTo( this.editor.editing.view, 'keydown', ( evt, data ) => {
-			let commandName;
-
-			if ( data.keystroke == parseKeystroke( 'Tab' ) ) {
-				commandName = 'indentList';
-			} else if ( data.keystroke == parseKeystroke( 'Shift+Tab' ) ) {
-				commandName = 'outdentList';
-			}
-
-			if ( commandName ) {
+		const getCommandExecuter = commandName => {
+			return ( data, cancel ) => {
 				const command = this.editor.commands.get( commandName );
 
 				if ( command.isEnabled ) {
 					this.editor.execute( commandName );
-
-					data.preventDefault();
-					evt.stop();
 				}
-			}
-		} );
+
+				cancel();
+			};
+		};
+
+		this.editor.keystrokes.set( 'Tab', getCommandExecuter( 'indentList' ) );
+		this.editor.keystrokes.set( 'Shift+Tab', getCommandExecuter( 'outdentList' ) );
 	}
 
 	/**

--- a/src/list.js
+++ b/src/list.js
@@ -67,9 +67,8 @@ export default class List extends Plugin {
 
 				if ( command.isEnabled ) {
 					this.editor.execute( commandName );
+					cancel();
 				}
-
-				cancel();
 			};
 		};
 

--- a/tests/list.js
+++ b/tests/list.js
@@ -121,8 +121,9 @@ describe( 'List', () => {
 
 		beforeEach( () => {
 			domEvtDataStub = {
-				keystroke: getCode( 'Tab' ),
-				preventDefault() {}
+				keyCode: getCode( 'Tab' ),
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
 			};
 
 			sinon.spy( editor, 'execute' );
@@ -143,10 +144,12 @@ describe( 'List', () => {
 
 			expect( editor.execute.calledOnce ).to.be.true;
 			expect( editor.execute.calledWithExactly( 'indentList' ) ).to.be.true;
+			sinon.assert.calledOnce( domEvtDataStub.preventDefault );
+			sinon.assert.calledOnce( domEvtDataStub.stopPropagation );
 		} );
 
 		it( 'should execute outdentList command on Shift+Tab keystroke', () => {
-			domEvtDataStub.keystroke += getCode( 'Shift' );
+			domEvtDataStub.keyCode += getCode( 'Shift' );
 
 			setData(
 				doc,
@@ -158,6 +161,8 @@ describe( 'List', () => {
 
 			expect( editor.execute.calledOnce ).to.be.true;
 			expect( editor.execute.calledWithExactly( 'outdentList' ) ).to.be.true;
+			sinon.assert.calledOnce( domEvtDataStub.preventDefault );
+			sinon.assert.calledOnce( domEvtDataStub.stopPropagation );
 		} );
 
 		it( 'should not indent if command is disabled', () => {
@@ -166,10 +171,12 @@ describe( 'List', () => {
 			editor.editing.view.fire( 'keydown', domEvtDataStub );
 
 			expect( editor.execute.called ).to.be.false;
+			sinon.assert.notCalled( domEvtDataStub.preventDefault );
+			sinon.assert.notCalled( domEvtDataStub.stopPropagation );
 		} );
 
 		it( 'should not indent or outdent if alt+tab is pressed', () => {
-			domEvtDataStub.keystroke += getCode( 'alt' );
+			domEvtDataStub.keyCode += getCode( 'alt' );
 
 			setData(
 				doc,
@@ -180,6 +187,8 @@ describe( 'List', () => {
 			editor.editing.view.fire( 'keydown', domEvtDataStub );
 
 			expect( editor.execute.called ).to.be.false;
+			sinon.assert.notCalled( domEvtDataStub.preventDefault );
+			sinon.assert.notCalled( domEvtDataStub.stopPropagation );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: List feature should use EditingKeystrokeHandler instead of direct event listeners. Closes ckeditor/ckeditor5#2992.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-core/pull/102.