### PR TITLE
Fixed: `modelChangePostFixer` works correctly when item is moved out of container.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^0.8.1",
+	"@ckeditor/ckeditor5-block-quote": "^0.1.1",
     "@ckeditor/ckeditor5-clipboard": "^0.6.0",
     "@ckeditor/ckeditor5-dev-lint": "^3.1.0",
     "@ckeditor/ckeditor5-editor-classic": "^0.7.3",

--- a/src/converters.js
+++ b/src/converters.js
@@ -574,20 +574,19 @@ export function modelChangePostFixer( document ) {
 			return;
 		}
 
-		let sourcePos;
-
-		if ( changes.sourcePosition ) {
-			const howMany = changes.range.end.offset - changes.range.start.offset;
-			sourcePos = changes.sourcePosition._getTransformedByInsertion( changes.range.start, howMany, true );
-		}
-
 		if ( type == 'remove' ) {
+			const howMany = changes.range.end.offset - changes.range.start.offset;
+			const sourcePos = changes.sourcePosition._getTransformedByInsertion( changes.range.start, howMany, true );
+
 			// Fix list items after the cut-out range.
 			// This fix is needed if items in model after cut-out range have now wrong indents compared to their previous siblings.
 			_fixItemsIndent( sourcePos, document, batch );
 			// This fix is needed if two different nested lists got merged, change types of list items "below".
 			_fixItemsType( sourcePos, false, document, batch );
 		} else if ( type == 'move' ) {
+			const howMany = changes.range.end.offset - changes.range.start.offset;
+			const sourcePos = changes.sourcePosition._getTransformedByInsertion( changes.range.start, howMany, true );
+
 			// Fix list items after the cut-out range.
 			// This fix is needed if items in model after cut-out range have now wrong indents compared to their previous siblings.
 			_fixItemsIndent( sourcePos, document, batch );

--- a/src/converters.js
+++ b/src/converters.js
@@ -574,18 +574,25 @@ export function modelChangePostFixer( document ) {
 			return;
 		}
 
+		let sourcePos;
+
+		if ( changes.sourcePosition ) {
+			const howMany = changes.range.end.offset - changes.range.start.offset;
+			sourcePos = changes.sourcePosition._getTransformedByInsertion( changes.range.start, howMany, true );
+		}
+
 		if ( type == 'remove' ) {
 			// Fix list items after the cut-out range.
 			// This fix is needed if items in model after cut-out range have now wrong indents compared to their previous siblings.
-			_fixItemsIndent( changes.sourcePosition, document, batch );
+			_fixItemsIndent( sourcePos, document, batch );
 			// This fix is needed if two different nested lists got merged, change types of list items "below".
-			_fixItemsType( changes.sourcePosition, false, document, batch );
+			_fixItemsType( sourcePos, false, document, batch );
 		} else if ( type == 'move' ) {
 			// Fix list items after the cut-out range.
 			// This fix is needed if items in model after cut-out range have now wrong indents compared to their previous siblings.
-			_fixItemsIndent( changes.sourcePosition, document, batch );
+			_fixItemsIndent( sourcePos, document, batch );
 			// This fix is needed if two different nested lists got merged, change types of list items "below".
-			_fixItemsType( changes.sourcePosition, false, document, batch );
+			_fixItemsType( sourcePos, false, document, batch );
 
 			// Fix items in moved range.
 			// This fix is needed if inserted items are too deeply intended.

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -17,6 +17,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import BoldEngine from '@ckeditor/ckeditor5-basic-styles/src/boldengine';
 import UndoEngine from '@ckeditor/ckeditor5-undo/src/undoengine';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
+import BlockQuoteEngine from '@ckeditor/ckeditor5-block-quote/src/blockquoteengine';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import { getData as getModelData, setData as setModelData, parse as parseModel } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -28,7 +29,7 @@ describe( 'ListEngine', () => {
 	beforeEach( () => {
 		return VirtualTestEditor
 			.create( {
-				plugins: [ Clipboard, BoldEngine, Paragraph, ListEngine, UndoEngine ]
+				plugins: [ Clipboard, BoldEngine, Paragraph, ListEngine, UndoEngine, BlockQuoteEngine ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -2998,6 +2999,29 @@ describe( 'ListEngine', () => {
 				'<listItem indent="0" type="bulleted">d</listItem>' +
 				'<listItem indent="1" type="bulleted">e</listItem>' +
 				'<listItem indent="1" type="bulleted">i</listItem>'
+			);
+
+			// #78.
+			test(
+				'move out of container',
+
+				'<blockQuote>' +
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem indent="1" type="bulleted">c</listItem>' +
+					'<listItem indent="1" type="bulleted">d</listItem>' +
+					'[<listItem indent="2" type="bulleted">e</listItem>]' +
+				'</blockQuote>',
+
+				0,
+
+				'<listItem indent="0" type="bulleted">e</listItem>' +
+				'<blockQuote>' +
+					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem indent="1" type="bulleted">c</listItem>' +
+					'<listItem indent="1" type="bulleted">d</listItem>' +
+				'</blockQuote>'
 			);
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed a bug when editor sometimes crashed when list item was moved outside and before a container in which it was. Closes ckeditor/ckeditor5#2993.