### PR TITLE
Indent fixer callback should not crash editor when "empty content" is inserted.

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -738,7 +738,7 @@ export function modelIndentPasteFixer( evt, [ content, selection ] ) {
 	// would create incorrect model.
 	let item = content.is( 'documentFragment' ) ? content.getChild( 0 ) : content;
 
-	if ( item.is( 'listItem' ) ) {
+	if ( item && item.is( 'listItem' ) ) {
 		// Get a reference list item. Inserted list items will be fixed according to that item.
 		const pos = selection.getFirstPosition();
 		let refItem = null;

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -3257,6 +3257,14 @@ describe( 'ListEngine', () => {
 				'<paragraph>B</paragraph>'
 			);
 		} );
+
+		it( 'should not crash when "empty content" is inserted', () => {
+			setModelData( modelDoc, '<paragraph>[]</paragraph>' );
+
+			expect( () => {
+				editor.data.insertContent( new ModelDocumentFragment(), modelDoc.selection );
+			} ).not.to.throw();
+		} );
 	} );
 
 	describe( 'other', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Editor was crashing in certain cases during pasting when pasted content could not be converted at all. Closes ckeditor/ckeditor5#2995.