### PR TITLE
Set 'bulleted' as default list type if list item is pasted without parent

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -356,10 +356,11 @@ export function viewModelConverter( evt, data, consumable, conversionApi ) {
 
 		// 2. Handle `listItem` model element attributes.
 		data.indent = data.indent ? data.indent : 0;
-
-		const type = data.input.parent.name == 'ul' ? 'bulleted' : 'numbered';
-		listItem.setAttribute( 'type', type );
 		listItem.setAttribute( 'indent', data.indent );
+
+		// Set 'bulleted' as default. If this item is pasted into a context,
+		const type = data.input.parent && data.input.parent.name == 'ol' ? 'numbered' : 'bulleted';
+		listItem.setAttribute( 'type', type );
 
 		// 3. Handle `<li>` children.
 		data.context.push( listItem );

--- a/tests/listengine.js
+++ b/tests/listengine.js
@@ -3265,6 +3265,55 @@ describe( 'ListEngine', () => {
 				editor.data.insertContent( new ModelDocumentFragment(), modelDoc.selection );
 			} ).not.to.throw();
 		} );
+
+		it( 'should correctly handle item that is pasted without its parent', () => {
+			setModelData( modelDoc,
+				'<paragraph>Foo</paragraph>' +
+				'<listItem type="numbered" indent="0">A</listItem>' +
+				'<listItem type="numbered" indent="1">B</listItem>' +
+				'[]' +
+				'<paragraph>Bar</paragraph>'
+			);
+
+			const clipboard = editor.plugins.get( 'Clipboard' );
+
+			clipboard.fire( 'inputTransformation', {
+				content: parseView( '<li>X</li>' )
+			} );
+
+			expect( getModelData( modelDoc ) ).to.equal(
+				'<paragraph>Foo</paragraph>' +
+				'<listItem indent="0" type="numbered">A</listItem>' +
+				'<listItem indent="1" type="numbered">B</listItem>' +
+				'<listItem indent="1" type="numbered">X[]</listItem>' +
+				'<paragraph>Bar</paragraph>'
+			);
+		} );
+
+		it( 'should correctly handle item that is pasted without its parent #2', () => {
+			setModelData( modelDoc,
+				'<paragraph>Foo</paragraph>' +
+				'<listItem type="numbered" indent="0">A</listItem>' +
+				'<listItem type="numbered" indent="1">B</listItem>' +
+				'[]' +
+				'<paragraph>Bar</paragraph>'
+			);
+
+			const clipboard = editor.plugins.get( 'Clipboard' );
+
+			clipboard.fire( 'inputTransformation', {
+				content: parseView( '<li>X<ul><li>Y</li></ul></li>' )
+			} );
+
+			expect( getModelData( modelDoc ) ).to.equal(
+				'<paragraph>Foo</paragraph>' +
+				'<listItem indent="0" type="numbered">A</listItem>' +
+				'<listItem indent="1" type="numbered">B</listItem>' +
+				'<listItem indent="1" type="numbered">X</listItem>' +
+				'<listItem indent="2" type="bulleted">Y[]</listItem>' +
+				'<paragraph>Bar</paragraph>'
+			);
+		} );
 	} );
 
 	describe( 'other', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Editor will no longer crash when spellchecker corrects a word inside list item in certain scenario. Closes ckeditor/ckeditor5#2989.