### PR TITLE
Fix: Backspace at first LI should not merge with previous block.

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -61,6 +61,28 @@ export default class List extends Plugin {
 			}
 		} );
 
+		// Overwrite default Backspace key behavior.
+		// If Backspace key is pressed with selection collapsed on first position in first list item, outdent it.
+		this.listenTo( this.editor.editing.view, 'delete', ( evt, data ) => {
+			const selection = this.editor.document.selection;
+			const positionParent = selection.getLastPosition().parent;
+
+			const isInListItem = positionParent.name === 'listItem';
+			const previousIsNotAListItem = !positionParent.previousSibling || positionParent.previousSibling.name !== 'listItem';
+
+			const isBackward = data.direction === 'backward';
+
+			const firstPosition = selection.getFirstPosition();
+			const isAtStart = firstPosition.isAtStart;
+
+			if ( isInListItem && previousIsNotAListItem && isBackward && selection.isCollapsed && isAtStart ) {
+				this.editor.execute( 'outdentList' );
+
+				data.preventDefault();
+				evt.stop();
+			}
+		}, { priority: 'high' } );
+
 		const getCommandExecuter = commandName => {
 			return ( data, cancel ) => {
 				const command = this.editor.commands.get( commandName );

--- a/tests/list.js
+++ b/tests/list.js
@@ -116,6 +116,68 @@ describe( 'List', () => {
 		} );
 	} );
 
+	describe( 'delete key handling callback', () => {
+		it( 'should execute outdentList command on backspace key in first item of list', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			expect( editor.execute.calledWithExactly( 'outdentList' ) );
+		} );
+
+		it( 'should execute outdentList command on backspace key in first item of list', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<paragraph>foo</paragraph><listItem type="bulleted" indent="0">[]foo</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			expect( editor.execute.calledWithExactly( 'outdentList' ) );
+		} );
+
+		it( 'should not execute outdentList command on backspace key not in first place in list', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'forward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">fo[]o</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should not execute outdentList command on delete key in first item of list', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'forward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should not execute outdentList command when selection is not collapsed', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">[fo]o</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+	} );
+
 	describe( 'tab key handling callback', () => {
 		let domEvtDataStub;
 

--- a/tests/list.js
+++ b/tests/list.js
@@ -10,6 +10,7 @@ import ListEngine from '../src/listengine';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -21,7 +22,7 @@ describe( 'List', () => {
 		const editorElement = document.createElement( 'div' );
 		document.body.appendChild( editorElement );
 
-		return ClassicTestEditor.create( editorElement, { plugins: [ Paragraph, List ] } )
+		return ClassicTestEditor.create( editorElement, { plugins: [ Paragraph, BlockQuote, List ] } )
 			.then( newEditor => {
 				editor = newEditor;
 				doc = editor.document;
@@ -141,18 +142,6 @@ describe( 'List', () => {
 			expect( editor.execute.calledWithExactly( 'outdentList' ) );
 		} );
 
-		it( 'should not execute outdentList command on backspace key not in first place in list', () => {
-			const domEvtDataStub = { preventDefault() {}, direction: 'forward' };
-
-			sinon.spy( editor, 'execute' );
-
-			setData( doc, '<listItem type="bulleted" indent="0">fo[]o</listItem>' );
-
-			editor.editing.view.fire( 'delete', domEvtDataStub );
-
-			sinon.assert.notCalled( editor.execute );
-		} );
-
 		it( 'should not execute outdentList command on delete key in first item of list', () => {
 			const domEvtDataStub = { preventDefault() {}, direction: 'forward' };
 
@@ -175,6 +164,78 @@ describe( 'List', () => {
 			editor.editing.view.fire( 'delete', domEvtDataStub );
 
 			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should not execute outdentList command if not in list item', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<paragraph>[]foo</paragraph>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should not execute outdentList command if not in first list item', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">foo</listItem><listItem type="bulleted" indent="0">[]foo</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should not execute outdentList command when selection is not on first position', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">fo[]o</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should not execute outdentList command when selection is not on first position', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<listItem type="bulleted" indent="0">fo[]o</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			sinon.assert.notCalled( editor.execute );
+		} );
+
+		it( 'should outdent list when previous element is nested in block quote', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<blockQuote><paragraph>x</paragraph></blockQuote><listItem type="bulleted" indent="0">[]foo</listItem>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			expect( editor.execute.calledWithExactly( 'outdentList' ) );
+		} );
+
+		it( 'should outdent list when list is nested in block quote', () => {
+			const domEvtDataStub = { preventDefault() {}, direction: 'backward' };
+
+			sinon.spy( editor, 'execute' );
+
+			setData( doc, '<paragraph>x</paragraph><blockQuote><listItem type="bulleted" indent="0">[]foo</listItem></blockQuote>' );
+
+			editor.editing.view.fire( 'delete', domEvtDataStub );
+
+			expect( editor.execute.calledWithExactly( 'outdentList' ) );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Pressing <kbd>Backspace</kbd> at the beginning of a first list item will turn it into a paragraph instead of merging with the previous block. Closes ckeditor/ckeditor5#2987.

---

### Additional information

* I didn't dig much into `getFirstPosition`/`getLastPosition` difference in this scenario so I'll read about this more later since I didn't catch the difference here if `selection.isCollapsed`
* probably some comments are needed as there are many  cases to check for this particular case which should only listen to `backspace` not `delete` on collapsed selection and only in first item of list.
