### PR TITLE
Fixed: List postfixers should check if attribute is allowed od elemen…

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -130,7 +130,7 @@ export function modelViewChangeType( evt, data, conversionApi ) {
 }
 
 /**
- * A model-to-view converter for `indent` attribute change on `listItem` model element.
+ * A model-to-view converter for `listIndent` attribute change on `listItem` model element.
  *
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the fired event.
@@ -331,7 +331,7 @@ export function modelViewMergeAfter( evt, data, conversionApi ) {
 /**
  * A view-to-model converter that converts `<li>` view elements into `listItem` model elements.
  *
- * To set correct values of the `listType` and `indent` attributes the converter:
+ * To set correct values of the `listType` and `listIndent` attributes the converter:
  * * checks `<li>`'s parent,
  * * stores and increases the `conversionApi.store.indent` value when `<li>`'s sub-items are converted.
  *

--- a/src/converters.js
+++ b/src/converters.js
@@ -31,15 +31,15 @@ export function modelViewInsertion( evt, data, conversionApi ) {
 	const consumable = conversionApi.consumable;
 
 	if ( !consumable.test( data.item, 'insert' ) ||
-		!consumable.test( data.item, 'attribute:type' ) ||
-		!consumable.test( data.item, 'attribute:indent' )
+		!consumable.test( data.item, 'attribute:listType' ) ||
+		!consumable.test( data.item, 'attribute:listIndent' )
 	) {
 		return;
 	}
 
 	consumable.consume( data.item, 'insert' );
-	consumable.consume( data.item, 'attribute:type' );
-	consumable.consume( data.item, 'attribute:indent' );
+	consumable.consume( data.item, 'attribute:listType' );
+	consumable.consume( data.item, 'attribute:listIndent' );
 
 	const modelItem = data.item;
 	const viewItem = generateLiInUl( modelItem, conversionApi );
@@ -79,7 +79,7 @@ export function modelViewRemove( evt, data, conversionApi ) {
 	// 4. Bring back nested list that was in the removed <li>.
 	const modelItem = conversionApi.mapper.toModelElement( viewItem );
 
-	hoistNestedLists( modelItem.getAttribute( 'indent' ) + 1, data.position, removeRange.start, viewItem, conversionApi );
+	hoistNestedLists( modelItem.getAttribute( 'listIndent' ) + 1, data.position, removeRange.start, viewItem, conversionApi );
 
 	// 5. Unbind removed view item and all children.
 	for ( const child of ViewRange.createIn( removed ).getItems() ) {
@@ -101,7 +101,7 @@ export function modelViewRemove( evt, data, conversionApi ) {
  * @param {Object} conversionApi Conversion interface.
  */
 export function modelViewChangeType( evt, data, conversionApi ) {
-	if ( !conversionApi.consumable.consume( data.item, 'attribute:type' ) ) {
+	if ( !conversionApi.consumable.consume( data.item, 'attribute:listType' ) ) {
 		return;
 	}
 
@@ -138,7 +138,7 @@ export function modelViewChangeType( evt, data, conversionApi ) {
  * @param {Object} conversionApi Conversion interface.
  */
 export function modelViewChangeIndent( evt, data, conversionApi ) {
-	if ( !conversionApi.consumable.consume( data.item, 'attribute:indent' ) ) {
+	if ( !conversionApi.consumable.consume( data.item, 'attribute:listIndent' ) ) {
 		return;
 	}
 
@@ -331,7 +331,7 @@ export function modelViewMergeAfter( evt, data, conversionApi ) {
 /**
  * A view-to-model converter that converts `<li>` view elements into `listItem` model elements.
  *
- * To set correct values of the `type` and `indent` attributes the converter:
+ * To set correct values of the `listType` and `indent` attributes the converter:
  * * checks `<li>`'s parent,
  * * stores and increases the `conversionApi.store.indent` value when `<li>`'s sub-items are converted.
  *
@@ -350,11 +350,11 @@ export function viewModelConverter( evt, data, conversionApi ) {
 
 		// 2. Handle `listItem` model element attributes.
 		conversionStore.indent = conversionStore.indent || 0;
-		writer.setAttribute( 'indent', conversionStore.indent, listItem );
+		writer.setAttribute( 'listIndent', conversionStore.indent, listItem );
 
 		// Set 'bulleted' as default. If this item is pasted into a context,
 		const type = data.viewItem.parent && data.viewItem.parent.name == 'ol' ? 'numbered' : 'bulleted';
-		writer.setAttribute( 'type', type, listItem );
+		writer.setAttribute( 'listType', type, listItem );
 
 		// `listItem`s created recursively should have bigger indent.
 		conversionStore.indent++;
@@ -570,19 +570,19 @@ export function viewToModelPosition( evt, data ) {
  * In an example below, there is a correct list structure.
  * Then the middle element will be removed so the list structure will become incorrect:
  *
- *		<listItem type="bulleted" indent=0>Item 1</listItem>
- *		<listItem type="bulleted" indent=1>Item 2</listItem>   <--- this is removed.
- *		<listItem type="bulleted" indent=2>Item 3</listItem>
+ *		<listItem listType="bulleted" listIndent=0>Item 1</listItem>
+ *		<listItem listType="bulleted" listIndent=1>Item 2</listItem>   <--- this is removed.
+ *		<listItem listType="bulleted" listIndent=2>Item 3</listItem>
  *
  * List structure after the middle element removed:
  *
- * 		<listItem type="bulleted" indent=0>Item 1</listItem>
- *		<listItem type="bulleted" indent=2>Item 3</listItem>
+ * 		<listItem listType="bulleted" listIndent=0>Item 1</listItem>
+ *		<listItem listType="bulleted" listIndent=2>Item 3</listItem>
  *
  * Should become:
  *
- *		<listItem type="bulleted" indent=0>Item 1</listItem>
- *		<listItem type="bulleted" indent=1>Item 3</listItem>   <--- note that indent got post-fixed.
+ *		<listItem listType="bulleted" listIndent=0>Item 1</listItem>
+ *		<listItem listType="bulleted" listIndent=1>Item 3</listItem>   <--- note that indent got post-fixed.
  *
  * @param {module:engine/model/model~Model} model The data model.
  * @param {module:engine/model/writer~Writer} writer The writer to do changes with.
@@ -602,14 +602,14 @@ export function modelChangePostFixer( model, writer ) {
 				// In case of renamed element.
 				const item = entry.position.nodeAfter;
 
-				if ( item.hasAttribute( 'indent' ) ) {
-					writer.removeAttribute( 'indent', item );
+				if ( item.hasAttribute( 'listIndent' ) ) {
+					writer.removeAttribute( 'listIndent', item );
 
 					applied = true;
 				}
 
-				if ( item.hasAttribute( 'type' ) ) {
-					writer.removeAttribute( 'type', item );
+				if ( item.hasAttribute( 'listType' ) ) {
+					writer.removeAttribute( 'listType', item );
 
 					applied = true;
 				}
@@ -620,9 +620,9 @@ export function modelChangePostFixer( model, writer ) {
 			_addListToFix( posAfter );
 		} else if ( entry.type == 'remove' && entry.name == 'listItem' ) {
 			_addListToFix( entry.position );
-		} else if ( entry.type == 'attribute' && entry.attributeKey == 'indent' ) {
+		} else if ( entry.type == 'attribute' && entry.attributeKey == 'listIndent' ) {
 			_addListToFix( entry.range.start );
-		} else if ( entry.type == 'attribute' && entry.attributeKey == 'type' ) {
+		} else if ( entry.type == 'attribute' && entry.attributeKey == 'listType' ) {
 			_addListToFix( entry.range.start );
 		}
 	}
@@ -667,7 +667,7 @@ export function modelChangePostFixer( model, writer ) {
 		let fixBy = null;
 
 		while ( item && item.is( 'listItem' ) ) {
-			const itemIndent = item.getAttribute( 'indent' );
+			const itemIndent = item.getAttribute( 'listIndent' );
 
 			if ( itemIndent > maxIndent ) {
 				let newIndent;
@@ -683,12 +683,12 @@ export function modelChangePostFixer( model, writer ) {
 					newIndent = itemIndent - fixBy;
 				}
 
-				writer.setAttribute( 'indent', newIndent, item );
+				writer.setAttribute( 'listIndent', newIndent, item );
 
 				applied = true;
 			} else {
 				fixBy = null;
-				maxIndent = item.getAttribute( 'indent' ) + 1;
+				maxIndent = item.getAttribute( 'listIndent' ) + 1;
 			}
 
 			item = item.nextSibling;
@@ -700,9 +700,9 @@ export function modelChangePostFixer( model, writer ) {
 		let prev = null;
 
 		while ( item && item.is( 'listItem' ) ) {
-			const itemIndent = item.getAttribute( 'indent' );
+			const itemIndent = item.getAttribute( 'listIndent' );
 
-			if ( prev && prev.getAttribute( 'indent' ) > itemIndent ) {
+			if ( prev && prev.getAttribute( 'listIndent' ) > itemIndent ) {
 				typesStack = typesStack.slice( 0, itemIndent + 1 );
 			}
 
@@ -710,13 +710,13 @@ export function modelChangePostFixer( model, writer ) {
 				if ( typesStack[ itemIndent ] ) {
 					const type = typesStack[ itemIndent ];
 
-					if ( item.getAttribute( 'type' ) != type ) {
-						writer.setAttribute( 'type', type, item );
+					if ( item.getAttribute( 'listType' ) != type ) {
+						writer.setAttribute( 'listType', type, item );
 
 						applied = true;
 					}
 				} else {
-					typesStack[ itemIndent ] = item.getAttribute( 'type' );
+					typesStack[ itemIndent ] = item.getAttribute( 'listType' );
 				}
 			}
 
@@ -733,18 +733,18 @@ export function modelChangePostFixer( model, writer ) {
  *
  * Example:
  *
- *		<listItem type="bulleted" indent=0>A</listItem>
- *		<listItem type="bulleted" indent=1>B^</listItem>
- *		// At ^ paste:  <listItem type="bulleted" indent=4>X</listItem>
- *		//              <listItem type="bulleted" indent=5>Y</listItem>
- *		<listItem type="bulleted" indent=2>C</listItem>
+ *		<listItem listType="bulleted" listIndent=0>A</listItem>
+ *		<listItem listType="bulleted" listIndent=1>B^</listItem>
+ *		// At ^ paste:  <listItem listType="bulleted" listIndent=4>X</listItem>
+ *		//              <listItem listType="bulleted" listIndent=5>Y</listItem>
+ *		<listItem listType="bulleted" listIndent=2>C</listItem>
  *
  * Should become:
  *
- *		<listItem type="bulleted" indent=0>A</listItem>
- *		<listItem type="bulleted" indent=1>BX</listItem>
- *		<listItem type="bulleted" indent=2>Y/listItem>
- *		<listItem type="bulleted" indent=2>C</listItem>
+ *		<listItem listType="bulleted" listIndent=0>A</listItem>
+ *		<listItem listType="bulleted" listIndent=1>BX</listItem>
+ *		<listItem listType="bulleted" listIndent=2>Y/listItem>
+ *		<listItem listType="bulleted" listIndent=2>C</listItem>
  *
  * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the fired event.
  * @param {Array} args Arguments of {@link module:engine/model/model~Model#insertContent}.
@@ -773,13 +773,13 @@ export function modelIndentPasteFixer( evt, [ content, selection ] ) {
 			// First list item in `data` has indent equal to 0 (it is a first list item). It should have indent equal
 			// to the indent of reference item. We have to fix the first item and all of it's children and following siblings.
 			// Indent of all those items has to be adjusted to reference item.
-			const indentChange = refItem.getAttribute( 'indent' );
+			const indentChange = refItem.getAttribute( 'listIndent' );
 
 			// Fix only if there is anything to fix.
 			if ( indentChange > 0 ) {
 				// Adjust indent of all "first" list items in inserted data.
 				while ( item && item.is( 'listItem' ) ) {
-					item._setAttribute( 'indent', item.getAttribute( 'indent' ) + indentChange );
+					item._setAttribute( 'listIndent', item.getAttribute( 'listIndent' ) + indentChange );
 
 					item = item.nextSibling;
 				}
@@ -794,7 +794,7 @@ export function modelIndentPasteFixer( evt, [ content, selection ] ) {
 function generateLiInUl( modelItem, conversionApi ) {
 	const mapper = conversionApi.mapper;
 	const viewWriter = conversionApi.writer;
-	const listType = modelItem.getAttribute( 'type' ) == 'numbered' ? 'ol' : 'ul';
+	const listType = modelItem.getAttribute( 'listType' ) == 'numbered' ? 'ol' : 'ul';
 	const viewItem = createViewListItemElement( viewWriter );
 
 	const viewList = viewWriter.createContainerElement( listType, null );
@@ -815,11 +815,11 @@ function getSiblingListItem( modelItemOrPosition, options ) {
 	const sameIndent = !!options.sameIndent;
 	const smallerIndent = !!options.smallerIndent;
 
-	const indent = modelItemOrPosition instanceof ModelElement ? modelItemOrPosition.getAttribute( 'indent' ) : options.indent;
+	const indent = modelItemOrPosition instanceof ModelElement ? modelItemOrPosition.getAttribute( 'listIndent' ) : options.listIndent;
 	let item = modelItemOrPosition instanceof ModelElement ? modelItemOrPosition.previousSibling : modelItemOrPosition.nodeBefore;
 
 	while ( item && item.name == 'listItem' ) {
-		const itemIndent = item.getAttribute( 'indent' );
+		const itemIndent = item.getAttribute( 'listIndent' );
 
 		if ( ( sameIndent && indent == itemIndent ) || ( smallerIndent && indent > itemIndent ) ) {
 			return item;
@@ -859,7 +859,7 @@ function injectViewList( modelItem, injectedItem, conversionApi ) {
 	const refItem = getSiblingListItem( modelItem, { sameIndent: true, smallerIndent: true } );
 	const prevItem = modelItem.previousSibling;
 
-	if ( refItem && refItem.getAttribute( 'indent' ) == modelItem.getAttribute( 'indent' ) ) {
+	if ( refItem && refItem.getAttribute( 'listIndent' ) == modelItem.getAttribute( 'listIndent' ) ) {
 		// There is a list item with same indent - we found same-level sibling.
 		// Break the list after it. Inserted view item will be inserted in the broken space.
 		const viewItem = mapper.toViewElement( refItem );
@@ -915,7 +915,7 @@ function injectViewList( modelItem, injectedItem, conversionApi ) {
 			for ( const child of nextViewList.getChildren() ) {
 				const modelChild = mapper.toModelElement( child );
 
-				if ( modelChild && modelChild.getAttribute( 'indent' ) > modelItem.getAttribute( 'indent' ) ) {
+				if ( modelChild && modelChild.getAttribute( 'listIndent' ) > modelItem.getAttribute( 'listIndent' ) ) {
 					lastSubChild = child;
 				} else {
 					break;
@@ -944,14 +944,14 @@ function hoistNestedLists( nextIndent, modelRemoveStartPosition, viewRemoveStart
 	const prevModelItem = getSiblingListItem( modelRemoveStartPosition, {
 		sameIndent: true,
 		smallerIndent: true,
-		indent: nextIndent
+		listIndent: nextIndent
 	} );
 
 	const mapper = conversionApi.mapper;
 	const viewWriter = conversionApi.writer;
 
 	// Indent of found element or `null` if the element has not been found.
-	const prevIndent = prevModelItem ? prevModelItem.getAttribute( 'indent' ) : null;
+	const prevIndent = prevModelItem ? prevModelItem.getAttribute( 'listIndent' ) : null;
 
 	let insertPosition;
 

--- a/src/indentcommand.js
+++ b/src/indentcommand.js
@@ -60,7 +60,7 @@ export default class IndentCommand extends Command {
 			let next = lastItem.nextSibling;
 
 			// Check all items after last indented item, as long as their indent is bigger than indent of that item.
-			while ( next && next.name == 'listItem' && next.getAttribute( 'indent' ) > lastItem.getAttribute( 'indent' ) ) {
+			while ( next && next.name == 'listItem' && next.getAttribute( 'listIndent' ) > lastItem.getAttribute( 'listIndent' ) ) {
 				itemsToChange.push( next );
 
 				next = next.nextSibling;
@@ -75,7 +75,7 @@ export default class IndentCommand extends Command {
 			}
 
 			for ( const item of itemsToChange ) {
-				const indent = item.getAttribute( 'indent' ) + this._indentBy;
+				const indent = item.getAttribute( 'listIndent' ) + this._indentBy;
 
 				// If indent is lower than 0, it means that the item got outdented when it was not indented.
 				// This means that we need to convert that list item to paragraph.
@@ -87,7 +87,7 @@ export default class IndentCommand extends Command {
 				}
 				// If indent is >= 0, change the attribute value.
 				else {
-					writer.setAttribute( 'indent', indent, item );
+					writer.setAttribute( 'listIndent', indent, item );
 				}
 			}
 		} );
@@ -111,18 +111,18 @@ export default class IndentCommand extends Command {
 		if ( this._indentBy > 0 ) {
 			// Cannot indent first item in it's list. Check if before `listItem` is a list item that is in same list.
 			// To be in the same list, the item has to have same attributes and cannot be "split" by an item with lower indent.
-			const indent = listItem.getAttribute( 'indent' );
-			const type = listItem.getAttribute( 'type' );
+			const indent = listItem.getAttribute( 'listIndent' );
+			const type = listItem.getAttribute( 'listType' );
 
 			let prev = listItem.previousSibling;
 
-			while ( prev && prev.is( 'listItem' ) && prev.getAttribute( 'indent' ) >= indent ) {
-				if ( prev.getAttribute( 'indent' ) == indent ) {
+			while ( prev && prev.is( 'listItem' ) && prev.getAttribute( 'listIndent' ) >= indent ) {
+				if ( prev.getAttribute( 'listIndent' ) == indent ) {
 					// The item is on the same level.
 					// If it has same type, it means that we found a preceding sibling from the same list.
 					// If it does not have same type, it means that `listItem` is on different list (this can happen only
 					// on top level lists, though).
-					return prev.getAttribute( 'type' ) == type;
+					return prev.getAttribute( 'listType' ) == type;
 				}
 
 				prev = prev.previousSibling;

--- a/src/listcommand.js
+++ b/src/listcommand.js
@@ -122,10 +122,10 @@ export default class ListCommand extends Command {
 				// that this is the same effect that we would be get by multiple use of outdent command. However doing
 				// it like this is much more efficient because it's less operation (less memory usage, easier OT) and
 				// less conversion (faster).
-				while ( next && next.name == 'listItem' && next.getAttribute( 'indent' ) !== 0 ) {
+				while ( next && next.name == 'listItem' && next.getAttribute( 'listIndent' ) !== 0 ) {
 					// Check each next list item, as long as its indent is bigger than 0.
 					// If the indent is 0 we are not going to change anything anyway.
-					const indent = next.getAttribute( 'indent' );
+					const indent = next.getAttribute( 'listIndent' );
 
 					// We check if that's item indent is lower as current relative indent.
 					if ( indent < currentIndent ) {
@@ -140,7 +140,7 @@ export default class ListCommand extends Command {
 					// Save the entry in changes array. We do not apply it at the moment, because we will need to
 					// reverse the changes so the last item is changed first.
 					// This is to keep model in correct state all the time.
-					changes.push( { element: next, indent: newIndent } );
+					changes.push( { element: next, listIndent: newIndent } );
 
 					// Find next item.
 					next = next.nextSibling;
@@ -149,7 +149,7 @@ export default class ListCommand extends Command {
 				changes = changes.reverse();
 
 				for ( const item of changes ) {
-					writer.setAttribute( 'indent', item.indent, item.element );
+					writer.setAttribute( 'listIndent', item.listIndent, item.element );
 				}
 			}
 
@@ -176,8 +176,8 @@ export default class ListCommand extends Command {
 				let lowestIndent = Number.POSITIVE_INFINITY;
 
 				for ( const item of blocks ) {
-					if ( item.is( 'listItem' ) && item.getAttribute( 'indent' ) < lowestIndent ) {
-						lowestIndent = item.getAttribute( 'indent' );
+					if ( item.is( 'listItem' ) && item.getAttribute( 'listIndent' ) < lowestIndent ) {
+						lowestIndent = item.getAttribute( 'listIndent' );
 					}
 				}
 
@@ -203,12 +203,12 @@ export default class ListCommand extends Command {
 				} else if ( !turnOff && element.name != 'listItem' ) {
 					// We are turning on and the element is not a `listItem` - it should be converted to `listItem`.
 					// The order of operations is important to keep model in correct state.
-					writer.setAttributes( { type: this.type, indent: 0 }, element );
+					writer.setAttributes( { listType: this.type, listIndent: 0 }, element );
 					writer.rename( element, 'listItem' );
-				} else if ( !turnOff && element.name == 'listItem' && element.getAttribute( 'type' ) != this.type ) {
+				} else if ( !turnOff && element.name == 'listItem' && element.getAttribute( 'listType' ) != this.type ) {
 					// We are turning on and the element is a `listItem` but has different type - change it's type and
 					// type of it's all siblings that have same indent.
-					writer.setAttribute( 'type', this.type, element );
+					writer.setAttribute( 'listType', this.type, element );
 				}
 			}
 		} );
@@ -224,7 +224,7 @@ export default class ListCommand extends Command {
 		// Check whether closest `listItem` ancestor of the position has a correct type.
 		const listItem = first( this.editor.model.document.selection.getSelectedBlocks() );
 
-		return !!listItem && listItem.is( 'listItem' ) && listItem.getAttribute( 'type' ) == this.type;
+		return !!listItem && listItem.is( 'listItem' ) && listItem.getAttribute( 'listType' ) == this.type;
 	}
 
 	/**
@@ -280,17 +280,17 @@ function _fixType( blocks, isBackward, lowestIndent ) {
 		//     * ------		<-- should not be fixed, item is in different list, `indent` = 2, `indent` != `currentIndent`
 		//   * ------		<-- should be fixed, `indent` == 1 == `currentIndent`
 		// * ------			<-- break loop (`indent` < `lowestIndent`)
-		let currentIndent = startingItem.getAttribute( 'indent' );
+		let currentIndent = startingItem.getAttribute( 'listIndent' );
 
 		// Look back until a list item with indent lower than reference `lowestIndent`.
 		// That would be the parent of nested sublist which contains item having `lowestIndent`.
-		while ( item && item.is( 'listItem' ) && item.getAttribute( 'indent' ) >= lowestIndent ) {
-			if ( currentIndent > item.getAttribute( 'indent' ) ) {
-				currentIndent = item.getAttribute( 'indent' );
+		while ( item && item.is( 'listItem' ) && item.getAttribute( 'listIndent' ) >= lowestIndent ) {
+			if ( currentIndent > item.getAttribute( 'listIndent' ) ) {
+				currentIndent = item.getAttribute( 'listIndent' );
 			}
 
 			// Found an item that is in the same nested sublist.
-			if ( item.getAttribute( 'indent' ) == currentIndent ) {
+			if ( item.getAttribute( 'listIndent' ) == currentIndent ) {
 				// Just add the item to selected blocks like it was selected by the user.
 				blocks[ isBackward ? 'unshift' : 'push' ]( item );
 			}

--- a/src/listediting.js
+++ b/src/listediting.js
@@ -55,7 +55,7 @@ export default class ListEditing extends Plugin {
 		// If there are blocks allowed inside list item, algorithms using `getSelectedBlocks()` will have to be modified.
 		editor.model.schema.register( 'listItem', {
 			inheritAllFrom: '$block',
-			allowAttributes: [ 'type', 'indent' ]
+			allowAttributes: [ 'listType', 'listIndent' ]
 		} );
 
 		// Converters.
@@ -76,10 +76,10 @@ export default class ListEditing extends Plugin {
 		data.downcastDispatcher.on( 'insert', modelViewSplitOnInsert, { priority: 'high' } );
 		data.downcastDispatcher.on( 'insert:listItem', modelViewInsertion );
 
-		editing.downcastDispatcher.on( 'attribute:type:listItem', modelViewChangeType );
-		data.downcastDispatcher.on( 'attribute:type:listItem', modelViewChangeType );
-		editing.downcastDispatcher.on( 'attribute:indent:listItem', modelViewChangeIndent );
-		data.downcastDispatcher.on( 'attribute:indent:listItem', modelViewChangeIndent );
+		editing.downcastDispatcher.on( 'attribute:listType:listItem', modelViewChangeType );
+		data.downcastDispatcher.on( 'attribute:listType:listItem', modelViewChangeType );
+		editing.downcastDispatcher.on( 'attribute:listIndent:listItem', modelViewChangeIndent );
+		data.downcastDispatcher.on( 'attribute:listIndent:listItem', modelViewChangeIndent );
 
 		editing.downcastDispatcher.on( 'remove:listItem', modelViewRemove );
 		editing.downcastDispatcher.on( 'remove', modelViewMergeAfter, { priority: 'low' } );

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -23,19 +23,19 @@ describe( 'IndentCommand', () => {
 
 		model.schema.register( 'listItem', {
 			inheritAllFrom: '$block',
-			allowAttributes: [ 'type', 'indent' ]
+			allowAttributes: [ 'listType', 'listIndent' ]
 		} );
 		model.schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 
 		setData(
 			model,
-			'<listItem indent="0" type="bulleted">a</listItem>' +
-			'<listItem indent="0" type="bulleted">b</listItem>' +
-			'<listItem indent="1" type="bulleted">c</listItem>' +
-			'<listItem indent="2" type="bulleted">d</listItem>' +
-			'<listItem indent="2" type="bulleted">e</listItem>' +
-			'<listItem indent="1" type="bulleted">f</listItem>' +
-			'<listItem indent="0" type="bulleted">g</listItem>'
+			'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+			'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+			'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+			'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+			'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+			'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+			'<listItem listIndent="0" listType="bulleted">g</listItem>'
 		);
 	} );
 
@@ -71,11 +71,11 @@ describe( 'IndentCommand', () => {
 			it( 'should be false if selection starts in first list item #2', () => {
 				setData(
 					model,
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">[]d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">[]d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>'
 				);
 
 				expect( command.isEnabled ).to.be.false;
@@ -85,11 +85,11 @@ describe( 'IndentCommand', () => {
 			it( 'should be false if selection starts in first list item #3', () => {
 				setData(
 					model,
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="numbered">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
-					'<listItem indent="0" type="bulleted">[]e</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="numbered">c</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">[]e</listItem>'
 				);
 
 				expect( command.isEnabled ).to.be.false;
@@ -98,8 +98,8 @@ describe( 'IndentCommand', () => {
 			it( 'should be false if selection starts in first list item of top level list with different type than previous list', () => {
 				setData(
 					model,
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="numbered">[]b</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="numbered">[]b</listItem>'
 				);
 
 				expect( command.isEnabled ).to.be.false;
@@ -116,9 +116,9 @@ describe( 'IndentCommand', () => {
 			// Edge case but may happen that some other blocks will also use the indent attribute
 			// and before we fixed it the command was enabled in such a case.
 			it( 'should be false if selection starts in a paragraph with indent attribute', () => {
-				model.schema.extend( 'paragraph', { allowAttributes: 'indent' } );
+				model.schema.extend( 'paragraph', { allowAttributes: 'listIndent' } );
 
-				setData( model, '<listItem indent="0">a</listItem><paragraph indent="0">b[]</paragraph>' );
+				setData( model, '<listItem listIndent="0">a</listItem><paragraph listIndent="0">b[]</paragraph>' );
 
 				expect( command.isEnabled ).to.be.false;
 			} );
@@ -147,13 +147,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="2" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>' +
-					'<listItem indent="2" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 
@@ -165,13 +165,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="bulleted">c</listItem>' +
-					'<listItem indent="3" type="bulleted">d</listItem>' +
-					'<listItem indent="3" type="bulleted">e</listItem>' +
-					'<listItem indent="2" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 
@@ -186,13 +186,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="bulleted">c</listItem>' +
-					'<listItem indent="3" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>' +
-					'<listItem indent="1" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 		} );
@@ -246,13 +246,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="2" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>' +
-					'<listItem indent="0" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 
@@ -264,13 +264,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<paragraph indent="0" type="bulleted">a</paragraph>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="2" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>' +
-					'<listItem indent="1" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<paragraph listIndent="0" listType="bulleted">a</paragraph>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 
@@ -282,13 +282,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<paragraph indent="0" type="bulleted">b</paragraph>' +
-					'<listItem indent="0" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
-					'<listItem indent="1" type="bulleted">e</listItem>' +
-					'<listItem indent="0" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<paragraph listIndent="0" listType="bulleted">b</paragraph>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 
@@ -303,13 +303,13 @@ describe( 'IndentCommand', () => {
 				command.execute();
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal(
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<paragraph indent="0" type="bulleted">b</paragraph>' +
-					'<listItem indent="0" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>' +
-					'<listItem indent="1" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>'
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<paragraph listIndent="0" listType="bulleted">b</paragraph>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>'
 				);
 			} );
 		} );

--- a/tests/listcommand.js
+++ b/tests/listcommand.js
@@ -25,7 +25,7 @@ describe( 'ListCommand', () => {
 
 		model.schema.register( 'listItem', {
 			inheritAllFrom: '$block',
-			allowAttributes: [ 'type', 'indent' ]
+			allowAttributes: [ 'listType', 'listIndent' ]
 		} );
 		model.schema.register( 'paragraph', {
 			inheritAllFrom: '$block',
@@ -42,8 +42,8 @@ describe( 'ListCommand', () => {
 		setData(
 			model,
 			'<paragraph>foo</paragraph>' +
-			'<listItem type="bulleted" indent="0">bulleted</listItem>' +
-			'<listItem type="numbered" indent="0">numbered</listItem>' +
+			'<listItem listType="bulleted" listIndent="0">bulleted</listItem>' +
+			'<listItem listType="numbered" listIndent="0">numbered</listItem>' +
 			'<paragraph>bar</paragraph>' +
 			'<widget>' +
 				'<paragraph>xyz</paragraph>' +
@@ -98,7 +98,7 @@ describe( 'ListCommand', () => {
 
 		describe( 'isEnabled', () => {
 			it( 'should be true if entire selection is in a list', () => {
-				setData( model, '<listItem type="bulleted" indent="0">[a]</listItem>' );
+				setData( model, '<listItem listType="bulleted" listIndent="0">[a]</listItem>' );
 				expect( command.isEnabled ).to.be.true;
 			} );
 
@@ -141,24 +141,24 @@ describe( 'ListCommand', () => {
 
 					command.execute();
 
-					expect( getData( model ) ).to.equal( '<listItem indent="0" type="bulleted">fo[]o</listItem>' );
+					expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">fo[]o</listItem>' );
 				} );
 
 				it( 'should rename closest listItem to paragraph', () => {
-					setData( model, '<listItem indent="0" type="bulleted">fo[]o</listItem>' );
+					setData( model, '<listItem listIndent="0" listType="bulleted">fo[]o</listItem>' );
 
 					command.execute();
 
 					// Attributes will be removed by post fixer.
-					expect( getData( model ) ).to.equal( '<paragraph indent="0" type="bulleted">fo[]o</paragraph>' );
+					expect( getData( model ) ).to.equal( '<paragraph listIndent="0" listType="bulleted">fo[]o</paragraph>' );
 				} );
 
 				it( 'should change closest listItem\' type', () => {
-					setData( model, '<listItem indent="0" type="numbered">fo[]o</listItem>' );
+					setData( model, '<listItem listIndent="0" listType="numbered">fo[]o</listItem>' );
 
 					command.execute();
 
-					expect( getData( model ) ).to.equal( '<listItem indent="0" type="bulleted">fo[]o</listItem>' );
+					expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">fo[]o</listItem>' );
 				} );
 
 				it( 'should handle outdenting sub-items when list item is turned off', () => {
@@ -202,39 +202,39 @@ describe( 'ListCommand', () => {
 
 					setData(
 						model,
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">[]---</listItem>' +
-						'<listItem indent="3" type="bulleted">---</listItem>' +
-						'<listItem indent="4" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>' +
-						'<listItem indent="3" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>' +
-						'<listItem indent="3" type="bulleted">---</listItem>' +
-						'<listItem indent="3" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>'
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">[]---</listItem>' +
+						'<listItem listIndent="3" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="4" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="3" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="3" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="3" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>'
 					);
 
 					command.execute();
 
 					const expectedData =
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<paragraph indent="2" type="bulleted">[]---</paragraph>' + // Attributes will be removed by post fixer.
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>';
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<paragraph listIndent="2" listType="bulleted">[]---</paragraph>' + // Attributes will be removed by post fixer.
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>';
 
 					expect( getData( model ) ).to.equal( expectedData );
 				} );
@@ -244,14 +244,14 @@ describe( 'ListCommand', () => {
 				beforeEach( () => {
 					setData(
 						model,
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
 						'<paragraph>---</paragraph>' +
 						'<paragraph>---</paragraph>' +
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>'
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>'
 					);
 				} );
 
@@ -273,9 +273,9 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					expect( getData( model ) ).to.equal(
-						'<listItem indent="0" type="bulleted">a[bc</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">a[bc</listItem>' +
 						'<restricted><fooBlock></fooBlock></restricted>' +
-						'<listItem indent="0" type="bulleted">de]f</listItem>'
+						'<listItem listIndent="0" listType="bulleted">de]f</listItem>'
 					);
 				} );
 
@@ -296,9 +296,9 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					expect( getData( model ) ).to.equal(
-						'<listItem indent="0" type="bulleted">a[bc</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">a[bc</listItem>' +
 						'<image></image>' +
-						'<listItem indent="0" type="bulleted">de]f</listItem>'
+						'<listItem listIndent="0" listType="bulleted">de]f</listItem>'
 					);
 				} );
 
@@ -315,14 +315,14 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					const expectedData =
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">[---</listItem>' +
-						'<listItem indent="0" type="bulleted">---]</listItem>' +
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>';
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">[---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---]</listItem>' +
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>';
 
 					expect( getData( model ) ).to.equal( expectedData );
 				} );
@@ -341,14 +341,14 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					const expectedData =
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<paragraph indent="0" type="bulleted">[---</paragraph>' + // Attributes will be removed by post fixer.
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<paragraph listIndent="0" listType="bulleted">[---</paragraph>' + // Attributes will be removed by post fixer.
 						'<paragraph>---</paragraph>' +
 						'<paragraph>---</paragraph>' +
-						'<paragraph indent="0" type="numbered">---]</paragraph>' + // Attributes will be removed by post fixer.
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>';
+						'<paragraph listIndent="0" listType="numbered">---]</paragraph>' + // Attributes will be removed by post fixer.
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>';
 
 					expect( getData( model ) ).to.equal( expectedData );
 				} );
@@ -366,14 +366,14 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					const expectedData =
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
 						'<paragraph>---</paragraph>' +
 						'<paragraph>---</paragraph>' +
-						'<listItem indent="0" type="bulleted">[---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">]---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>';
+						'<listItem listIndent="0" listType="bulleted">[---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">]---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>';
 
 					expect( getData( model ) ).to.equal( expectedData );
 				} );
@@ -391,14 +391,14 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					const expectedData =
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<paragraph indent="0" type="bulleted">[---</paragraph>' + // Attributes will be removed by post fixer.
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<paragraph listIndent="0" listType="bulleted">[---</paragraph>' + // Attributes will be removed by post fixer.
 						'<paragraph>---</paragraph>' +
 						'<paragraph>---</paragraph>' +
-						'<paragraph indent="0" type="numbered">---</paragraph>' + // Attributes will be removed by post fixer.
-						'<paragraph indent="0" type="numbered">---]</paragraph>' + // Attributes will be removed by post fixer.
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>';
+						'<paragraph listIndent="0" listType="numbered">---</paragraph>' + // Attributes will be removed by post fixer.
+						'<paragraph listIndent="0" listType="numbered">---]</paragraph>' + // Attributes will be removed by post fixer.
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>';
 
 					expect( getData( model ) ).to.equal( expectedData );
 				} );
@@ -407,19 +407,19 @@ describe( 'ListCommand', () => {
 				it( 'should change type of all items in nested list if one of items changed', () => {
 					setData(
 						model,
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="numbered">---</listItem>' +
-						'<listItem indent="2" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="numbered">---</listItem>' +
-						'<listItem indent="2" type="numbered">---</listItem>' +
-						'<listItem indent="2" type="numbered">-[-</listItem>' +
-						'<listItem indent="1" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="numbered">---</listItem>' +
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="numbered">-]-</listItem>' +
-						'<listItem indent="1" type="numbered">---</listItem>' +
-						'<listItem indent="2" type="numbered">---</listItem>' +
-						'<listItem indent="0" type="numbered">---</listItem>'
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="numbered">---</listItem>' +
+						'<listItem listIndent="2" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="numbered">---</listItem>' +
+						'<listItem listIndent="2" listType="numbered">---</listItem>' +
+						'<listItem listIndent="2" listType="numbered">-[-</listItem>' +
+						'<listItem listIndent="1" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="numbered">---</listItem>' +
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="numbered">-]-</listItem>' +
+						'<listItem listIndent="1" listType="numbered">---</listItem>' +
+						'<listItem listIndent="2" listType="numbered">---</listItem>' +
+						'<listItem listIndent="0" listType="numbered">---</listItem>'
 					);
 
 					// * ------				<-- do not fix, top level item
@@ -439,19 +439,19 @@ describe( 'ListCommand', () => {
 					command.execute();
 
 					const expectedData =
-						'<listItem indent="0" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="numbered">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="bulleted">-[-</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="0" type="bulleted">---</listItem>' +
-						'<listItem indent="1" type="bulleted">-]-</listItem>' +
-						'<listItem indent="1" type="bulleted">---</listItem>' +
-						'<listItem indent="2" type="numbered">---</listItem>' +
-						'<listItem indent="0" type="numbered">---</listItem>';
+						'<listItem listIndent="0" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="numbered">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">-[-</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="0" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">-]-</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">---</listItem>' +
+						'<listItem listIndent="2" listType="numbered">---</listItem>' +
+						'<listItem listIndent="0" listType="numbered">---</listItem>';
 
 					expect( getData( model ) ).to.equal( expectedData );
 				} );

--- a/tests/listediting.js
+++ b/tests/listediting.js
@@ -48,7 +48,7 @@ describe( 'ListEditing', () => {
 
 				model.schema.register( 'foo', {
 					allowWhere: '$block',
-					allowAttributes: [ 'indent', 'type' ],
+					allowAttributes: [ 'listIndent', 'listType' ],
 					isBlock: true,
 					isObject: true
 				} );

--- a/tests/listediting.js
+++ b/tests/listediting.js
@@ -45,6 +45,13 @@ describe( 'ListEditing', () => {
 				view = editor.editing.view;
 				viewDoc = view.document;
 				viewRoot = viewDoc.getRoot();
+
+				model.schema.register( 'foo', {
+					allowWhere: '$block',
+					allowAttributes: [ 'indent', 'type' ],
+					isBlock: true,
+					isObject: true
+				} );
 			} );
 	} );
 
@@ -61,8 +68,8 @@ describe( 'ListEditing', () => {
 		expect( model.schema.checkChild( [ '$root', 'listItem' ], 'listItem' ) ).to.be.false;
 		expect( model.schema.checkChild( [ '$root', 'listItem' ], '$block' ) ).to.be.false;
 
-		expect( model.schema.checkAttribute( [ '$root', 'listItem' ], 'indent' ) ).to.be.true;
-		expect( model.schema.checkAttribute( [ '$root', 'listItem' ], 'type' ) ).to.be.true;
+		expect( model.schema.checkAttribute( [ '$root', 'listItem' ], 'listIndent' ) ).to.be.true;
+		expect( model.schema.checkAttribute( [ '$root', 'listItem' ], 'listType' ) ).to.be.true;
 	} );
 
 	describe( 'commands', () => {
@@ -87,7 +94,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">[]</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">[]</listItem>' );
 
 			editor.editing.view.document.fire( 'enter', domEvtDataStub );
 
@@ -100,7 +107,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">foo[]</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">foo[]</listItem>' );
 
 			editor.editing.view.document.fire( 'enter', domEvtDataStub );
 
@@ -114,7 +121,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">[]foo</listItem>' );
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
 
@@ -126,7 +133,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<paragraph>foo</paragraph><listItem type="bulleted" indent="0">[]foo</listItem>' );
+			setModelData( model, '<paragraph>foo</paragraph><listItem listType="bulleted" listIndent="0">[]foo</listItem>' );
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
 
@@ -138,7 +145,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">[]foo</listItem>' );
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
 
@@ -150,7 +157,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">[fo]o</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">[fo]o</listItem>' );
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
 
@@ -176,7 +183,7 @@ describe( 'ListEditing', () => {
 
 			setModelData(
 				model,
-				'<listItem type="bulleted" indent="0">foo</listItem><listItem type="bulleted" indent="0">[]foo</listItem>'
+				'<listItem listType="bulleted" listIndent="0">foo</listItem><listItem listType="bulleted" listIndent="0">[]foo</listItem>'
 			);
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
@@ -189,7 +196,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">fo[]o</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">fo[]o</listItem>' );
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
 
@@ -201,7 +208,7 @@ describe( 'ListEditing', () => {
 
 			sinon.spy( editor, 'execute' );
 
-			setModelData( model, '<listItem type="bulleted" indent="0">fo[]o</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">fo[]o</listItem>' );
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
 
@@ -215,7 +222,7 @@ describe( 'ListEditing', () => {
 
 			setModelData(
 				model,
-				'<blockQuote><paragraph>x</paragraph></blockQuote><listItem type="bulleted" indent="0">[]foo</listItem>'
+				'<blockQuote><paragraph>x</paragraph></blockQuote><listItem listType="bulleted" listIndent="0">[]foo</listItem>'
 			);
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
@@ -230,7 +237,7 @@ describe( 'ListEditing', () => {
 
 			setModelData(
 				model,
-				'<paragraph>x</paragraph><blockQuote><listItem type="bulleted" indent="0">[]foo</listItem></blockQuote>'
+				'<paragraph>x</paragraph><blockQuote><listItem listType="bulleted" listIndent="0">[]foo</listItem></blockQuote>'
 			);
 
 			editor.editing.view.document.fire( 'delete', domEvtDataStub );
@@ -259,8 +266,8 @@ describe( 'ListEditing', () => {
 		it( 'should execute indentList command on tab key', () => {
 			setModelData(
 				model,
-				'<listItem type="bulleted" indent="0">foo</listItem>' +
-				'<listItem type="bulleted" indent="0">[]bar</listItem>'
+				'<listItem listType="bulleted" listIndent="0">foo</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">[]bar</listItem>'
 			);
 
 			editor.editing.view.document.fire( 'keydown', domEvtDataStub );
@@ -276,8 +283,8 @@ describe( 'ListEditing', () => {
 
 			setModelData(
 				model,
-				'<listItem type="bulleted" indent="0">foo</listItem>' +
-				'<listItem type="bulleted" indent="1">[]bar</listItem>'
+				'<listItem listType="bulleted" listIndent="0">foo</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">[]bar</listItem>'
 			);
 
 			editor.editing.view.document.fire( 'keydown', domEvtDataStub );
@@ -289,7 +296,7 @@ describe( 'ListEditing', () => {
 		} );
 
 		it( 'should not indent if command is disabled', () => {
-			setModelData( model, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+			setModelData( model, '<listItem listType="bulleted" listIndent="0">[]foo</listItem>' );
 
 			editor.editing.view.document.fire( 'keydown', domEvtDataStub );
 
@@ -303,8 +310,8 @@ describe( 'ListEditing', () => {
 
 			setModelData(
 				model,
-				'<listItem type="bulleted" indent="0">foo</listItem>' +
-				'<listItem type="bulleted" indent="0">[]bar</listItem>'
+				'<listItem listType="bulleted" listIndent="0">foo</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">[]bar</listItem>'
 			);
 
 			editor.editing.view.document.fire( 'keydown', domEvtDataStub );
@@ -348,12 +355,12 @@ describe( 'ListEditing', () => {
 				editor.setData( '<ol><li>a</li></ol><p>xxx</p><ul><li>b</li><li>c</li></ul><p>yyy</p><ul><li>d</li></ul>' );
 
 				const expectedModelData =
-					'<listItem indent="0" type="numbered">a</listItem>' +
+					'<listItem listIndent="0" listType="numbered">a</listItem>' +
 					'<paragraph>xxx</paragraph>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="bulleted">c</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>' +
 					'<paragraph>yyy</paragraph>' +
-					'<listItem indent="0" type="bulleted">d</listItem>';
+					'<listItem listIndent="0" listType="bulleted">d</listItem>';
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal( expectedModelData );
 			} );
@@ -382,11 +389,11 @@ describe( 'ListEditing', () => {
 
 			/*
 				<paragraph>a</paragraph>
-				<listItem indent=0 type="bulleted">b</listItem>
-				<listItem indent=0 type="bulleted">c</listItem>
-				<listItem indent=0 type="bulleted">d</listItem>
+				<listItem listIndent=0 listType="bulleted">b</listItem>
+				<listItem listIndent=0 listType="bulleted">c</listItem>
+				<listItem listIndent=0 listType="bulleted">d</listItem>
 				<paragraph>e</paragraph>
-				<listItem indent=0 type="numbered">f</listItem>
+				<listItem listIndent=0 listType="numbered">f</listItem>
 				<paragraph>g</paragraph>
 			 */
 
@@ -443,8 +450,8 @@ describe( 'ListEditing', () => {
 					'list item at the beginning of same list type',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">x</listItem>]' +
-					'<listItem indent="0" type="bulleted">a</listItem>',
+					'[<listItem listIndent="0" listType="bulleted">x</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -457,9 +464,9 @@ describe( 'ListEditing', () => {
 					'list item in the middle of same list type',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">x</listItem>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">x</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -473,8 +480,8 @@ describe( 'ListEditing', () => {
 					'list item at the end of same list type',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">x</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">x</listItem>]',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -487,8 +494,8 @@ describe( 'ListEditing', () => {
 					'list item at the beginning of different list type',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="numbered">x</listItem>]' +
-					'<listItem indent="0" type="bulleted">a</listItem>',
+					'[<listItem listIndent="0" listType="numbered">x</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>',
 
 					'<p>p</p>' +
 					'<ol>' +
@@ -503,9 +510,9 @@ describe( 'ListEditing', () => {
 					'list item in the middle of different list type',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="numbered">x</listItem>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="numbered">x</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -523,8 +530,8 @@ describe( 'ListEditing', () => {
 					'list item at the end of different list type',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="numbered">x</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="numbered">x</listItem>]',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -538,9 +545,9 @@ describe( 'ListEditing', () => {
 				testInsert(
 					'element between list items',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="0" type="bulleted">a</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -557,9 +564,9 @@ describe( 'ListEditing', () => {
 					'remove the first list item',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">a</listItem>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="bulleted">c</listItem>',
+					'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -572,9 +579,9 @@ describe( 'ListEditing', () => {
 					'remove list item from the middle',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
-					'<listItem indent="0" type="bulleted">c</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -587,9 +594,9 @@ describe( 'ListEditing', () => {
 					'remove the last list item',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'[<listItem indent="0" type="bulleted">c</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">c</listItem>]',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -602,7 +609,7 @@ describe( 'ListEditing', () => {
 					'remove the only list item',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">x</listItem>]' +
+					'[<listItem listIndent="0" listType="bulleted">x</listItem>]' +
 					'<paragraph>p</paragraph>',
 
 					'<p>p</p>' +
@@ -613,9 +620,9 @@ describe( 'ListEditing', () => {
 					'remove element from between lists of same type',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
 					'<paragraph>p</paragraph>',
 
 					'<p>p</p>' +
@@ -630,9 +637,9 @@ describe( 'ListEditing', () => {
 					'remove element from between lists of different type',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="0" type="numbered">b</listItem>' +
+					'<listItem listIndent="0" listType="numbered">b</listItem>' +
 					'<paragraph>p</paragraph>',
 
 					'<p>p</p>' +
@@ -651,9 +658,9 @@ describe( 'ListEditing', () => {
 					'change first list item',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">a</listItem>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="bulleted">c</listItem>',
+					'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 					'<p>p</p>' +
 					'<ol>' +
@@ -669,9 +676,9 @@ describe( 'ListEditing', () => {
 					'change middle list item',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
-					'<listItem indent="0" type="bulleted">c</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -689,9 +696,9 @@ describe( 'ListEditing', () => {
 					'change last list item',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'[<listItem indent="0" type="bulleted">c</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">c</listItem>]',
 
 					'<p>p</p>' +
 					'<ul>' +
@@ -707,7 +714,7 @@ describe( 'ListEditing', () => {
 					'change only list item',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">a</listItem>]' +
+					'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
 					'<paragraph>p</paragraph>',
 
 					'<p>p</p>' +
@@ -720,10 +727,10 @@ describe( 'ListEditing', () => {
 				testChangeType(
 					'change element at the edge of two different lists #1',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
-					'[<listItem indent="0" type="bulleted">c</listItem>]' +
-					'<listItem indent="0" type="numbered">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="0" listType="numbered">d</listItem>',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -738,10 +745,10 @@ describe( 'ListEditing', () => {
 				testChangeType(
 					'change element at the edge of two different lists #1',
 
-					'<listItem indent="0" type="numbered">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
-					'<listItem indent="0" type="bulleted">c</listItem>' +
-					'<listItem indent="0" type="bulleted">d</listItem>',
+					'<listItem listIndent="0" listType="numbered">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">d</listItem>',
 
 					'<ol>' +
 						'<li>a</li>' +
@@ -756,10 +763,10 @@ describe( 'ListEditing', () => {
 				testChangeType(
 					'change multiple elements #1',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="bulleted">c</listItem>]' +
-					'<listItem indent="0" type="bulleted">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">d</listItem>',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -776,10 +783,10 @@ describe( 'ListEditing', () => {
 				testChangeType(
 					'change multiple elements #2',
 
-					'<listItem indent="0" type="numbered">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>' +
-					'<listItem indent="0" type="bulleted">c</listItem>]' +
-					'<listItem indent="0" type="numbered">d</listItem>',
+					'<listItem listIndent="0" listType="numbered">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="0" listType="numbered">d</listItem>',
 
 					'<ol>' +
 						'<li>a</li>' +
@@ -794,8 +801,8 @@ describe( 'ListEditing', () => {
 				testRenameFromListItem(
 					'rename first list item',
 
-					'[<listItem indent="0" type="bulleted">a</listItem>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>',
+					'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>',
 
 					'<p>a</p>' +
 					'<ul>' +
@@ -806,9 +813,9 @@ describe( 'ListEditing', () => {
 				testRenameFromListItem(
 					'rename middle list item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
-					'<listItem indent="0" type="bulleted">c</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -822,8 +829,8 @@ describe( 'ListEditing', () => {
 				testRenameFromListItem(
 					'rename last list item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -835,7 +842,7 @@ describe( 'ListEditing', () => {
 					'rename only list item',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">x</listItem>]' +
+					'[<listItem listIndent="0" listType="bulleted">x</listItem>]' +
 					'<paragraph>p</paragraph>',
 
 					'<p>p</p>' +
@@ -873,7 +880,7 @@ describe( 'ListEditing', () => {
 					'element before list of same type', 0,
 
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="0" type="bulleted">a</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>',
 
 					'<ul>' +
 						'<li>x</li>' +
@@ -884,7 +891,7 @@ describe( 'ListEditing', () => {
 				testRenameToListItem(
 					'element after list of same type', 0,
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
 					'[<paragraph>x</paragraph>]',
 
 					'<ul>' +
@@ -897,7 +904,7 @@ describe( 'ListEditing', () => {
 					'element before list of different type', 0,
 
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="0" type="numbered">a</listItem>',
+					'<listItem listIndent="0" listType="numbered">a</listItem>',
 
 					'<ul>' +
 						'<li>x</li>' +
@@ -910,7 +917,7 @@ describe( 'ListEditing', () => {
 				testRenameToListItem(
 					'element after list of different type', 0,
 
-					'<listItem indent="0" type="numbered">a</listItem>' +
+					'<listItem listIndent="0" listType="numbered">a</listItem>' +
 					'[<paragraph>x</paragraph>]',
 
 					'<ol>' +
@@ -924,9 +931,9 @@ describe( 'ListEditing', () => {
 				testRenameToListItem(
 					'element between lists of same type', 0,
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="0" type="bulleted">b</listItem>',
+					'<listItem listIndent="0" listType="bulleted">b</listItem>',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -941,9 +948,9 @@ describe( 'ListEditing', () => {
 					'list item inside same list',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
-					'<listItem indent="0" type="bulleted">c</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 					4, // Move after last item.
 
@@ -959,8 +966,8 @@ describe( 'ListEditing', () => {
 					'out list item from list',
 
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
 					'<paragraph>p</paragraph>',
 
 					4, // Move after second paragraph.
@@ -979,7 +986,7 @@ describe( 'ListEditing', () => {
 					'the only list item',
 
 					'<paragraph>p</paragraph>' +
-					'[<listItem indent="0" type="bulleted">a</listItem>]' +
+					'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
 					'<paragraph>p</paragraph>',
 
 					3, // Move after second paragraph.
@@ -994,11 +1001,11 @@ describe( 'ListEditing', () => {
 				testMove(
 					'list item between two lists of same type',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="bulleted">c</listItem>' +
-					'<listItem indent="0" type="bulleted">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">d</listItem>',
 
 					4, // Move between list item "c" and list item "d'.
 
@@ -1016,11 +1023,11 @@ describe( 'ListEditing', () => {
 				testMove(
 					'list item between two lists of different type',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
 					'<paragraph>p</paragraph>' +
-					'<listItem indent="0" type="numbered">c</listItem>' +
-					'<listItem indent="0" type="numbered">d</listItem>',
+					'<listItem listIndent="0" listType="numbered">c</listItem>' +
+					'<listItem listIndent="0" listType="numbered">d</listItem>',
 
 					4, // Move between list item "c" and list item "d'.
 
@@ -1042,8 +1049,8 @@ describe( 'ListEditing', () => {
 				testMove(
 					'element between list items',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="0" type="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">b</listItem>' +
 					'[<paragraph>p</paragraph>]',
 
 					1, // Move between list item "a" and list item "b'.
@@ -1312,12 +1319,12 @@ describe( 'ListEditing', () => {
 
 				const expectedModelData =
 					'<paragraph>foo</paragraph>' +
-					'<listItem indent="0" type="bulleted">1</listItem>' +
-					'<listItem indent="1" type="bulleted">1.1</listItem>' +
-					'<listItem indent="1" type="bulleted">1.2</listItem>' +
-					'<listItem indent="2" type="numbered">1.2.1</listItem>' +
-					'<listItem indent="1" type="bulleted">1.3</listItem>' +
-					'<listItem indent="0" type="bulleted">2</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">1.1</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">1.2</listItem>' +
+					'<listItem listIndent="2" listType="numbered">1.2.1</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">1.3</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">2</listItem>' +
 					'<paragraph>bar</paragraph>';
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal( expectedModelData );
@@ -1355,17 +1362,17 @@ describe( 'ListEditing', () => {
 			} );
 
 			/*
-				<listItem indent=0 type="bulleted">a</listItem>
-				<listItem indent=0 type="bulleted">bbb</listItem>
-				<listItem indent=1 type="numbered">c</listItem>
-				<listItem indent=1 type="numbered">d</listItem>
-				<listItem indent=1 type="numbered">e</listItem>
-				<listItem indent=1 type="numbered"></listItem>
-				<listItem indent=2 type="bulleted">g</listItem>
-				<listItem indent=2 type="bulleted">h</listItem>
-				<listItem indent=2 type="bullered">i</listItem>
-				<listItem indent=1 type="numbered">j</listItem>
-				<listItem indent=0 type="bulleted">k</listItem>
+				<listItem listIndent=0 listType="bulleted">a</listItem>
+				<listItem listIndent=0 listType="bulleted">bbb</listItem>
+				<listItem listIndent=1 listType="numbered">c</listItem>
+				<listItem listIndent=1 listType="numbered">d</listItem>
+				<listItem listIndent=1 listType="numbered">e</listItem>
+				<listItem listIndent=1 listType="numbered"></listItem>
+				<listItem listIndent=2 listType="bulleted">g</listItem>
+				<listItem listIndent=2 listType="bulleted">h</listItem>
+				<listItem listIndent=2 listType="bullered">i</listItem>
+				<listItem listIndent=1 listType="numbered">j</listItem>
+				<listItem listIndent=0 listType="bulleted">k</listItem>
 			 */
 
 			describe( 'view to model', () => {
@@ -1446,8 +1453,8 @@ describe( 'ListEditing', () => {
 						'after smaller indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'[<listItem indent="1" type="bulleted">x</listItem>]',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">x</listItem>]',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1464,9 +1471,9 @@ describe( 'ListEditing', () => {
 						'after smaller indent, before same indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'[<listItem indent="1" type="bulleted">x</listItem>]' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">x</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1484,9 +1491,9 @@ describe( 'ListEditing', () => {
 						'after smaller indent, before smaller indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'[<listItem indent="1" type="bulleted">x</listItem>]' +
-						'<listItem indent="0" type="bulleted">2</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">x</listItem>]' +
+						'<listItem listIndent="0" listType="bulleted">2</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1504,9 +1511,9 @@ describe( 'ListEditing', () => {
 						'after same indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>' +
-						'[<listItem indent="1" type="bulleted">x</listItem>]',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">x</listItem>]',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1524,9 +1531,9 @@ describe( 'ListEditing', () => {
 						'after same indent, before bigger indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'[<listItem indent="0" type="bulleted">x</listItem>]' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'[<listItem listIndent="0" listType="bulleted">x</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1544,10 +1551,10 @@ describe( 'ListEditing', () => {
 						'after bigger indent, before bigger indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>' +
-						'[<listItem indent="0" type="bulleted">x</listItem>]' +
-						'<listItem indent="1" type="bulleted">1.2</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>' +
+						'[<listItem listIndent="0" listType="bulleted">x</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">1.2</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1569,12 +1576,12 @@ describe( 'ListEditing', () => {
 					testInsert(
 						'list items with too big indent',
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="4" type="bulleted">x</listItem>' + // This indent should be fixed by post fixer.
-						'<listItem indent="5" type="bulleted">x</listItem>' + // This indent should be fixed by post fixer.
-						'<listItem indent="4" type="bulleted">x</listItem>]' + // This indent should be fixed by post fixer.
-						'<listItem indent="1" type="bulleted">c</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="4" listType="bulleted">x</listItem>' + // This indent should be fixed by post fixer.
+						'<listItem listIndent="5" listType="bulleted">x</listItem>' + // This indent should be fixed by post fixer.
+						'<listItem listIndent="4" listType="bulleted">x</listItem>]' + // This indent should be fixed by post fixer.
+						'<listItem listIndent="1" listType="bulleted">c</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -1604,9 +1611,9 @@ describe( 'ListEditing', () => {
 						'after smaller indent, before same indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'[<listItem indent="1" type="numbered">x</listItem>]' + // This type should be fixed by post fixer.
-						'<listItem indent="1" type="bulleted">1.1</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'[<listItem listIndent="1" listType="numbered">x</listItem>]' + // This type should be fixed by post fixer.
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1624,9 +1631,9 @@ describe( 'ListEditing', () => {
 						'after same indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>' +
-						'[<listItem indent="1" type="numbered">x</listItem>]', // This type should be fixed by post fixer.
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>' +
+						'[<listItem listIndent="1" listType="numbered">x</listItem>]', // This type should be fixed by post fixer.
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1644,9 +1651,9 @@ describe( 'ListEditing', () => {
 						'after same indent, before bigger indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'[<listItem indent="0" type="numbered">x</listItem>]' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'[<listItem listIndent="0" listType="numbered">x</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1666,10 +1673,10 @@ describe( 'ListEditing', () => {
 						'after bigger indent, before bigger indent',
 
 						'<paragraph>p</paragraph>' +
-						'<listItem indent="0" type="bulleted">1</listItem>' +
-						'<listItem indent="1" type="bulleted">1.1</listItem>' +
-						'[<listItem indent="0" type="numbered">x</listItem>]' +
-						'<listItem indent="1" type="bulleted">1.2</listItem>',
+						'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">1.1</listItem>' +
+						'[<listItem listIndent="0" listType="numbered">x</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">1.2</listItem>',
 
 						'<p>p</p>' +
 						'<ul>' +
@@ -1693,10 +1700,10 @@ describe( 'ListEditing', () => {
 					testInsert(
 						'after bigger indent, in nested list, different type',
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'<listItem indent="2" type="bulleted">c</listItem>' +
-						'[<listItem indent="1" type="numbered">x</listItem>]', // This type should be fixed by post fixer.
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+						'[<listItem listIndent="1" listType="numbered">x</listItem>]', // This type should be fixed by post fixer.
 
 						'<ul>' +
 							'<li>' +
@@ -1719,17 +1726,17 @@ describe( 'ListEditing', () => {
 				testInsert(
 					'element between nested list items - complex',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="bulleted">c</listItem>' +
-					'<listItem indent="3" type="numbered">d</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="3" listType="numbered">d</listItem>' +
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="3" type="numbered">e</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="2" type="bulleted">f</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="3" type="bulleted">g</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="1" type="bulleted">h</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="2" type="numbered">i</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="0" type="numbered">j</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="3" listType="numbered">e</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="2" listType="bulleted">f</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="3" listType="bulleted">g</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="1" listType="bulleted">h</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="2" listType="numbered">i</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="0" listType="numbered">j</listItem>' + // This indent should be fixed by post fixer.
 					'<paragraph>p</paragraph>',
 
 					'<ul>' +
@@ -1779,11 +1786,11 @@ describe( 'ListEditing', () => {
 				testInsert(
 					'element before indent "hole"',
 
-					'<listItem indent="0" type="bulleted">1</listItem>' +
-					'<listItem indent="1" type="bulleted">1.1</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">1</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">1.1</listItem>' +
 					'[<paragraph>x</paragraph>]' +
-					'<listItem indent="2" type="bulleted">1.1.1</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="0" type="bulleted">2</listItem>',
+					'<listItem listIndent="2" listType="bulleted">1.1.1</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="0" listType="bulleted">2</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -1805,8 +1812,8 @@ describe( 'ListEditing', () => {
 				_test(
 					'two list items with mismatched types inserted in one batch',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>[]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>[]',
 
 					'<ul>' +
 						'<li>' +
@@ -1820,8 +1827,8 @@ describe( 'ListEditing', () => {
 					'</ul>',
 
 					() => {
-						const item1 = '<listItem indent="1" type="numbered">c</listItem>';
-						const item2 = '<listItem indent="1" type="bulleted">d</listItem>';
+						const item1 = '<listItem listIndent="1" listType="numbered">c</listItem>';
+						const item2 = '<listItem listIndent="1" listType="bulleted">d</listItem>';
 
 						model.change( writer => {
 							writer.append( parseModel( item1, model.schema ), modelRoot );
@@ -1835,9 +1842,9 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'the first nested item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="1" type="bulleted">b</listItem>]' +
-					'<listItem indent="1" type="bulleted">c</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -1852,10 +1859,10 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'nested item from the middle',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="1" type="bulleted">c</listItem>]' +
-					'<listItem indent="1" type="bulleted">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -1871,9 +1878,9 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'the last nested item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="1" type="bulleted">c</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">c</listItem>]',
 
 					'<ul>' +
 						'<li>' +
@@ -1888,8 +1895,8 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'the only nested item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="1" type="bulleted">c</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">c</listItem>]',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -1899,10 +1906,10 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'list item that separates two nested lists of same type',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="numbered">b</listItem>' +
-					'[<listItem indent="0" type="bulleted">c</listItem>]' +
-					'<listItem indent="1" type="numbered">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="numbered">b</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="1" listType="numbered">d</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -1918,10 +1925,10 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'list item that separates two nested lists of different type',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="numbered">b</listItem>' +
-					'[<listItem indent="0" type="bulleted">c</listItem>]' +
-					'<listItem indent="1" type="bulleted">d</listItem>', // This type should be fixed by post fixer.
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="numbered">b</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>', // This type should be fixed by post fixer.
 
 					'<ul>' +
 						'<li>' +
@@ -1937,10 +1944,10 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'item that has nested lists, previous item has same indent',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="0" type="bulleted">b</listItem>]' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -1956,10 +1963,10 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'item that has nested lists, previous item has smaller indent',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="1" type="bulleted">b</listItem>]' +
-					'<listItem indent="2" type="bulleted">c</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="2" type="bulleted">d</listItem>', // This indent should be fixed by post fixer.
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">b</listItem>]' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="2" listType="bulleted">d</listItem>', // This indent should be fixed by post fixer.
 
 					'<ul>' +
 						'<li>' +
@@ -1975,11 +1982,11 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'item that has nested lists, previous item has bigger indent by 1',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="0" type="bulleted">c</listItem>]' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="numbered">e</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="numbered">e</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -2000,11 +2007,11 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'item that has nested lists, previous item has bigger indent by 2',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="bulleted">c</listItem>' +
-					'[<listItem indent="0" type="bulleted">d</listItem>]' +
-					'<listItem indent="1" type="bulleted">e</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'[<listItem listIndent="0" listType="bulleted">d</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">e</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -2025,9 +2032,9 @@ describe( 'ListEditing', () => {
 				testRemove(
 					'first list item that has nested list',
 
-					'[<listItem indent="0" type="bulleted">a</listItem>]' +
-					'<listItem indent="1" type="bulleted">b</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="2" type="bulleted">c</listItem>', // This indent should be fixed by post fixer.
+					'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="2" listType="bulleted">c</listItem>', // This indent should be fixed by post fixer.
 
 					'<ul>' +
 						'<li>' +
@@ -2044,9 +2051,9 @@ describe( 'ListEditing', () => {
 				testChangeType(
 					'list item that has nested items',
 
-					'[<listItem indent="0" type="numbered">a</listItem>]' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>',
+					'[<listItem listIndent="0" listType="numbered">a</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -2063,10 +2070,10 @@ describe( 'ListEditing', () => {
 				testChangeType(
 					'list item that is a nested item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="numbered">b</listItem>' +
-					'[<listItem indent="1" type="numbered">c</listItem>]' +
-					'<listItem indent="1" type="numbered">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="numbered">b</listItem>' +
+					'[<listItem listIndent="1" listType="numbered">c</listItem>]' +
+					'<listItem listIndent="1" listType="numbered">d</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -2086,8 +2093,8 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent last item of flat list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="0" type="bulleted">b</listItem>]',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="0" listType="bulleted">b</listItem>]',
 
 						'<ul>' +
 							'<li>' +
@@ -2102,9 +2109,9 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent middle item of flat list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="0" type="bulleted">b</listItem>]' +
-						'<listItem indent="0" type="bulleted">c</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+						'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2120,9 +2127,9 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent last item in nested list', 2,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="1" type="bulleted">c</listItem>]',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">c</listItem>]',
 
 						'<ul>' +
 							'<li>' +
@@ -2142,10 +2149,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent middle item in nested list', 2,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="1" type="bulleted">c</listItem>]' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">c</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2170,9 +2177,9 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent item that has nested list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="0" type="bulleted">b</listItem>]' +
-						'<listItem indent="1" type="bulleted">c</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="0" listType="bulleted">b</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">c</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2188,10 +2195,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent item that in view is a next sibling of item that has nested list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="0" type="bulleted">c</listItem>]' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="0" listType="bulleted">c</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2208,10 +2215,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent the first item of nested list', 0,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="1" type="bulleted">b</listItem>]' +
-						'<listItem indent="1" type="bulleted">c</listItem>' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">b</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>a</li>' +
@@ -2228,10 +2235,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent item from the middle of nested list', 0,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="1" type="bulleted">c</listItem>]' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">c</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2252,9 +2259,9 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent the last item of nested list', 0,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="1" type="bulleted">c</listItem>]',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">c</listItem>]',
 
 						'<ul>' +
 							'<li>' +
@@ -2270,10 +2277,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent the only item of nested list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="2" type="bulleted">c</listItem>]' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2290,10 +2297,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent item by two', 0,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="2" type="bulleted">c</listItem>]' +
-						'<listItem indent="0" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+						'<listItem listIndent="0" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2312,9 +2319,9 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent middle item of flat list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="0" type="numbered">b</listItem>]' +
-						'<listItem indent="0" type="bulleted">c</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="0" listType="numbered">b</listItem>]' +
+						'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2330,9 +2337,9 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent item that has nested list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="0" type="numbered">b</listItem>]' +
-						'<listItem indent="1" type="bulleted">c</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="0" listType="numbered">b</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">c</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2348,10 +2355,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'indent item that in view is a next sibling of item that has nested list #1', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="0" type="numbered">c</listItem>]' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="0" listType="numbered">c</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2368,10 +2375,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent the first item of nested list', 0,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'[<listItem indent="1" type="bulleted">b</listItem>]' +
-						'<listItem indent="1" type="bulleted">c</listItem>' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'[<listItem listIndent="1" listType="bulleted">b</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>a</li>' +
@@ -2388,10 +2395,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent the only item of nested list', 1,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="2" type="bulleted">c</listItem>]' +
-						'<listItem indent="1" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+						'<listItem listIndent="1" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2408,10 +2415,10 @@ describe( 'ListEditing', () => {
 					testChangeIndent(
 						'outdent item by two', 0,
 
-						'<listItem indent="0" type="bulleted">a</listItem>' +
-						'<listItem indent="1" type="bulleted">b</listItem>' +
-						'[<listItem indent="2" type="numbered">c</listItem>]' +
-						'<listItem indent="0" type="bulleted">d</listItem>',
+						'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+						'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+						'[<listItem listIndent="2" listType="numbered">c</listItem>]' +
+						'<listItem listIndent="0" listType="bulleted">d</listItem>',
 
 						'<ul>' +
 							'<li>' +
@@ -2435,10 +2442,10 @@ describe( 'ListEditing', () => {
 				testRenameFromListItem(
 					'rename nested item from the middle #1',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="1" type="bulleted">c</listItem>]' +
-					'<listItem indent="1" type="bulleted">d</listItem>', // This indent should be fixed by post fixer.
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>', // This indent should be fixed by post fixer.
 
 					'<ul>' +
 						'<li>' +
@@ -2461,19 +2468,19 @@ describe( 'ListEditing', () => {
 
 					// Indents in this example should be fixed by post fixer.
 					// This nightmare example checks if structure of the list is kept as intact as possible.
-					'<listItem indent="0" type="bulleted">a</listItem>' +	// a --------			-->  a --------
-					'<listItem indent="1" type="bulleted">b</listItem>' +	//   b --------			-->    b --------
-					'[<listItem indent="2" type="bulleted">c</listItem>]' +	//     c --------		--> --------
-					'<listItem indent="3" type="bulleted">d</listItem>' +	//       d --------		-->  d --------
-					'<listItem indent="3" type="bulleted">e</listItem>' +	//       e --------		-->  e --------
-					'<listItem indent="4" type="bulleted">f</listItem>' +	//         f --------	-->    f --------
-					'<listItem indent="2" type="bulleted">g</listItem>' +	//     g --------		-->  g --------
-					'<listItem indent="3" type="bulleted">h</listItem>' +	//       h --------		-->    h --------
-					'<listItem indent="4" type="bulleted">i</listItem>' +	//         i --------	-->      i --------
-					'<listItem indent="1" type="bulleted">j</listItem>' +	//   j --------			-->  j --------
-					'<listItem indent="2" type="bulleted">k</listItem>' +	//     k --------		-->    k --------
-					'<listItem indent="0" type="bulleted">l</listItem>' +	// l --------			-->  l --------
-					'<listItem indent="1" type="bulleted">m</listItem>',	//   m --------			-->    m --------
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +	// a --------			-->  a --------
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +	//   b --------			-->    b --------
+					'[<listItem listIndent="2" listType="bulleted">c</listItem>]' +	//     c --------		--> --------
+					'<listItem listIndent="3" listType="bulleted">d</listItem>' +	//       d --------		-->  d --------
+					'<listItem listIndent="3" listType="bulleted">e</listItem>' +	//       e --------		-->  e --------
+					'<listItem listIndent="4" listType="bulleted">f</listItem>' +	//         f --------	-->    f --------
+					'<listItem listIndent="2" listType="bulleted">g</listItem>' +	//     g --------		-->  g --------
+					'<listItem listIndent="3" listType="bulleted">h</listItem>' +	//       h --------		-->    h --------
+					'<listItem listIndent="4" listType="bulleted">i</listItem>' +	//         i --------	-->      i --------
+					'<listItem listIndent="1" listType="bulleted">j</listItem>' +	//   j --------			-->  j --------
+					'<listItem listIndent="2" listType="bulleted">k</listItem>' +	//     k --------		-->    k --------
+					'<listItem listIndent="0" listType="bulleted">l</listItem>' +	// l --------			-->  l --------
+					'<listItem listIndent="1" listType="bulleted">m</listItem>',	//   m --------			-->    m --------
 
 					'<ul>' +
 						'<li>' +
@@ -2525,18 +2532,18 @@ describe( 'ListEditing', () => {
 
 					// Indents in this example should be fixed by post fixer.
 					// This example checks a bug found by testing manual test.
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="2" type="bulleted">c</listItem>]' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
-					'<listItem indent="2" type="bulleted">e</listItem>' +
-					'<listItem indent="2" type="bulleted">f</listItem>' +
-					'<listItem indent="2" type="bulleted">g</listItem>' +
-					'<listItem indent="2" type="bulleted">h</listItem>' +
-					'<listItem indent="0" type="bulleted"></listItem>' +
-					'<listItem indent="1" type="bulleted"></listItem>' +
-					'<listItem indent="2" type="numbered">k</listItem>' +
-					'<listItem indent="2" type="numbered">l</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">g</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">h</listItem>' +
+					'<listItem listIndent="0" listType="bulleted"></listItem>' +
+					'<listItem listIndent="1" listType="bulleted"></listItem>' +
+					'<listItem listIndent="2" listType="numbered">k</listItem>' +
+					'<listItem listIndent="2" listType="numbered">l</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -2575,8 +2582,8 @@ describe( 'ListEditing', () => {
 				testRenameFromListItem(
 					'rename the only nested item',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="1" type="bulleted">b</listItem>]',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">b</listItem>]',
 
 					'<ul>' +
 						'<li>a</li>' +
@@ -2589,7 +2596,7 @@ describe( 'ListEditing', () => {
 				testRenameToListItem(
 					'element into first item in nested list', 1,
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
 					'[<paragraph>b</paragraph>]',
 
 					'<ul>' +
@@ -2605,8 +2612,8 @@ describe( 'ListEditing', () => {
 				testRenameToListItem(
 					'element into last item in nested list', 1,
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 					'[<paragraph>c</paragraph>]',
 
 					'<ul>' +
@@ -2623,10 +2630,10 @@ describe( 'ListEditing', () => {
 				testRenameToListItem(
 					'element into a first item in deeply nested list', 2,
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 					'[<paragraph>c</paragraph>]' +
-					'<listItem indent="0" type="bulleted">d</listItem>',
+					'<listItem listIndent="0" listType="bulleted">d</listItem>',
 
 					'<ul>' +
 						'<li>' +
@@ -2650,11 +2657,11 @@ describe( 'ListEditing', () => {
 				testMove(
 					'out nested list items',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'[<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="bulleted">c</listItem>]' +
-					'<listItem indent="3" type="bulleted">d</listItem>' + // This indent should be fixed by post fixer.
-					'<listItem indent="4" type="bulleted">e</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="3" listType="bulleted">d</listItem>' + // This indent should be fixed by post fixer.
+					'<listItem listIndent="4" listType="bulleted">e</listItem>' + // This indent should be fixed by post fixer.
 					'<paragraph>x</paragraph>',
 
 					6,
@@ -2686,14 +2693,14 @@ describe( 'ListEditing', () => {
 				testMove(
 					'nested list items between lists of same type',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="2" type="bulleted">c</listItem>' +
-					'<listItem indent="3" type="bulleted">d</listItem>]' +
-					'<listItem indent="4" type="bulleted">e</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">d</listItem>]' +
+					'<listItem listIndent="4" listType="bulleted">e</listItem>' +
 					'<paragraph>x</paragraph>' +
-					'<listItem indent="0" type="bulleted">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>',
+					'<listItem listIndent="0" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>',
 
 					7,
 
@@ -2730,14 +2737,14 @@ describe( 'ListEditing', () => {
 				testMove(
 					'nested list items between lists of different type',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="2" type="bulleted">c</listItem>' +
-					'<listItem indent="3" type="bulleted">d</listItem>]' +
-					'<listItem indent="4" type="bulleted">e</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">d</listItem>]' +
+					'<listItem listIndent="4" listType="bulleted">e</listItem>' +
 					'<paragraph>x</paragraph>' +
-					'<listItem indent="0" type="numbered">f</listItem>' +
-					'<listItem indent="1" type="numbered">g</listItem>',
+					'<listItem listIndent="0" listType="numbered">f</listItem>' +
+					'<listItem listIndent="1" listType="numbered">g</listItem>',
 
 					7,
 
@@ -2774,10 +2781,10 @@ describe( 'ListEditing', () => {
 				testMove(
 					'element between nested list',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="2" type="bulleted">c</listItem>' +
-					'<listItem indent="3" type="bulleted">d</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">d</listItem>' +
 					'[<paragraph>x</paragraph>]',
 
 					2,
@@ -2806,15 +2813,15 @@ describe( 'ListEditing', () => {
 				testMove(
 					'multiple nested list items of different types #1 - fix at start',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="0" type="bulleted">d</listItem>' +
-					'<listItem indent="1" type="numbered">e</listItem>]' +
-					'<listItem indent="1" type="numbered">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>' +
-					'<listItem indent="1" type="numbered">h</listItem>' +
-					'<listItem indent="1" type="numbered">i</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="1" listType="numbered">e</listItem>]' +
+					'<listItem listIndent="1" listType="numbered">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>' +
+					'<listItem listIndent="1" listType="numbered">h</listItem>' +
+					'<listItem listIndent="1" listType="numbered">i</listItem>',
 
 					8,
 
@@ -2846,15 +2853,15 @@ describe( 'ListEditing', () => {
 				testMove(
 					'multiple nested list items of different types #2 - fix at end',
 
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="0" type="bulleted">d</listItem>' +
-					'<listItem indent="1" type="numbered">e</listItem>]' +
-					'<listItem indent="1" type="numbered">f</listItem>' +
-					'<listItem indent="0" type="bulleted">g</listItem>' +
-					'<listItem indent="1" type="bulleted">h</listItem>' +
-					'<listItem indent="1" type="bulleted">i</listItem>',
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="1" listType="numbered">e</listItem>]' +
+					'<listItem listIndent="1" listType="numbered">f</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">g</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">h</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">i</listItem>',
 
 					8,
 
@@ -2903,128 +2910,128 @@ describe( 'ListEditing', () => {
 			test(
 				'element before nested list',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 				'[]' +
-				'<listItem indent="2" type="bulleted">d</listItem>' +
-				'<listItem indent="2" type="bulleted">e</listItem>' +
-				'<listItem indent="3" type="bulleted">f</listItem>',
+				'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+				'<listItem listIndent="3" listType="bulleted">f</listItem>',
 
 				'<paragraph>x</paragraph>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 				'<paragraph>x</paragraph>' +
-				'<listItem indent="0" type="bulleted">d</listItem>' +
-				'<listItem indent="0" type="bulleted">e</listItem>' +
-				'<listItem indent="1" type="bulleted">f</listItem>'
+				'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">e</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">f</listItem>'
 			);
 
 			test(
 				'list item before nested list',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 				'[]' +
-				'<listItem indent="2" type="bulleted">d</listItem>' +
-				'<listItem indent="2" type="bulleted">e</listItem>' +
-				'<listItem indent="3" type="bulleted">f</listItem>',
+				'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">e</listItem>' +
+				'<listItem listIndent="3" listType="bulleted">f</listItem>',
 
-				'<listItem indent="0" type="bulleted">x</listItem>',
+				'<listItem listIndent="0" listType="bulleted">x</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="0" type="bulleted">x</listItem>' +
-				'<listItem indent="1" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="bulleted">e</listItem>' +
-				'<listItem indent="2" type="bulleted">f</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">e</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">f</listItem>'
 			);
 
 			test(
 				'multiple list items with too big indent',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 				'[]' +
-				'<listItem indent="1" type="bulleted">c</listItem>',
+				'<listItem listIndent="1" listType="bulleted">c</listItem>',
 
-				'<listItem indent="4" type="bulleted">x</listItem>' +
-				'<listItem indent="5" type="bulleted">x</listItem>' +
-				'<listItem indent="4" type="bulleted">x</listItem>',
+				'<listItem listIndent="4" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="5" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="4" listType="bulleted">x</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">x</listItem>' +
-				'<listItem indent="3" type="bulleted">x</listItem>' +
-				'<listItem indent="2" type="bulleted">x</listItem>' +
-				'<listItem indent="1" type="bulleted">c</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="3" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>'
 			);
 
 			test(
 				'item with different type - top level list',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="0" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">b</listItem>' +
 				'[]' +
-				'<listItem indent="0" type="bulleted">c</listItem>',
+				'<listItem listIndent="0" listType="bulleted">c</listItem>',
 
-				'<listItem indent="0" type="numbered">x</listItem>',
+				'<listItem listIndent="0" listType="numbered">x</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="0" type="bulleted">b</listItem>' +
-				'<listItem indent="0" type="numbered">x</listItem>' +
-				'<listItem indent="0" type="bulleted">c</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="numbered">x</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">c</listItem>'
 			);
 
 			test(
 				'multiple items with different type - nested list',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 				'[]' +
-				'<listItem indent="2" type="bulleted">c</listItem>',
+				'<listItem listIndent="2" listType="bulleted">c</listItem>',
 
-				'<listItem indent="1" type="numbered">x</listItem>' +
-				'<listItem indent="2" type="numbered">x</listItem>',
+				'<listItem listIndent="1" listType="numbered">x</listItem>' +
+				'<listItem listIndent="2" listType="numbered">x</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="1" type="bulleted">x</listItem>' +
-				'<listItem indent="2" type="numbered">x</listItem>' +
-				'<listItem indent="2" type="numbered">c</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">x</listItem>' +
+				'<listItem listIndent="2" listType="numbered">x</listItem>' +
+				'<listItem listIndent="2" listType="numbered">c</listItem>'
 			);
 
 			test(
 				'item with different type, in nested list, after nested list',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">c</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">c</listItem>' +
 				'[]',
 
-				'<listItem indent="1" type="numbered">x</listItem>',
+				'<listItem listIndent="1" listType="numbered">x</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">c</listItem>' +
-				'<listItem indent="1" type="bulleted">x</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">x</listItem>'
 			);
 
 			it( 'two list items with mismatched types inserted in one batch', () => {
 				const input =
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>';
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>';
 
 				const output =
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>';
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">d</listItem>';
 
 				setModelData( model, input );
 
-				const item1 = '<listItem indent="1" type="numbered">c</listItem>';
-				const item2 = '<listItem indent="1" type="bulleted">d</listItem>';
+				const item1 = '<listItem listIndent="1" listType="numbered">c</listItem>';
+				const item2 = '<listItem listIndent="1" listType="bulleted">d</listItem>';
 
 				model.change( writer => {
 					writer.append( parseModel( item1, model.schema ), modelRoot );
@@ -3051,44 +3058,44 @@ describe( 'ListEditing', () => {
 			test(
 				'first list item',
 
-				'[<listItem indent="0" type="bulleted">a</listItem>]' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">c</listItem>',
+				'[<listItem listIndent="0" listType="bulleted">a</listItem>]' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">c</listItem>',
 
-				'<listItem indent="0" type="bulleted">b</listItem>' +
-				'<listItem indent="1" type="bulleted">c</listItem>'
+				'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>'
 			);
 
 			test(
 				'first list item of nested list',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'[<listItem indent="1" type="bulleted">b</listItem>]' +
-				'<listItem indent="2" type="bulleted">c</listItem>' +
-				'<listItem indent="3" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="bulleted">e</listItem>' +
-				'<listItem indent="2" type="bulleted">f</listItem>',
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'[<listItem listIndent="1" listType="bulleted">b</listItem>]' +
+				'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="3" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">e</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">f</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">c</listItem>' +
-				'<listItem indent="2" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="bulleted">e</listItem>' +
-				'<listItem indent="2" type="bulleted">f</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">e</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">f</listItem>'
 			);
 
 			test(
 				'selection over two different nested lists of same indent',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'[<listItem indent="1" type="bulleted">c</listItem>' +
-				'<listItem indent="0" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="numbered">e</listItem>]' +
-				'<listItem indent="1" type="numbered">f</listItem>',
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'[<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="numbered">e</listItem>]' +
+				'<listItem listIndent="1" listType="numbered">f</listItem>',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="1" type="bulleted">f</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">f</listItem>'
 			);
 		} );
 
@@ -3110,115 +3117,115 @@ describe( 'ListEditing', () => {
 			test(
 				'nested list item out of list structure',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'[<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">c</listItem>]' +
-				'<listItem indent="3" type="bulleted">d</listItem>' +
-				'<listItem indent="4" type="bulleted">e</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'[<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+				'<listItem listIndent="3" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="4" listType="bulleted">e</listItem>' +
 				'<paragraph>x</paragraph>',
 
 				6,
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">d</listItem>' +
-				'<listItem indent="2" type="bulleted">e</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">e</listItem>' +
 				'<paragraph>x</paragraph>' +
-				'<listItem indent="0" type="bulleted">b</listItem>' +
-				'<listItem indent="1" type="bulleted">c</listItem>'
+				'<listItem listIndent="0" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>'
 			);
 
 			test(
 				'list items between lists',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'[<listItem indent="2" type="bulleted">c</listItem>' +
-				'<listItem indent="3" type="bulleted">d</listItem>]' +
-				'<listItem indent="4" type="bulleted">e</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'[<listItem listIndent="2" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="3" listType="bulleted">d</listItem>]' +
+				'<listItem listIndent="4" listType="bulleted">e</listItem>' +
 				'<paragraph>x</paragraph>' +
-				'<listItem indent="0" type="bulleted">f</listItem>' +
-				'<listItem indent="0" type="bulleted">g</listItem>',
+				'<listItem listIndent="0" listType="bulleted">f</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">g</listItem>',
 
 				7,
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">e</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">e</listItem>' +
 				'<paragraph>x</paragraph>' +
-				'<listItem indent="0" type="bulleted">f</listItem>' +
-				'<listItem indent="1" type="bulleted">c</listItem>' +
-				'<listItem indent="2" type="bulleted">d</listItem>' +
-				'<listItem indent="0" type="bulleted">g</listItem>'
+				'<listItem listIndent="0" listType="bulleted">f</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">g</listItem>'
 			);
 
 			test(
 				'element in between nested list items',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="2" type="bulleted">c</listItem>' +
-				'<listItem indent="3" type="bulleted">d</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="3" listType="bulleted">d</listItem>' +
 				'[<paragraph>x</paragraph>]',
 
 				2,
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 				'<paragraph>x</paragraph>' +
-				'<listItem indent="0" type="bulleted">c</listItem>' +
-				'<listItem indent="1" type="bulleted">d</listItem>'
+				'<listItem listIndent="0" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">d</listItem>'
 			);
 
 			test(
 				'multiple nested list items of different types #1 - fix at start',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'[<listItem indent="1" type="bulleted">c</listItem>' +
-				'<listItem indent="0" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="numbered">e</listItem>]' +
-				'<listItem indent="1" type="numbered">f</listItem>' +
-				'<listItem indent="0" type="bulleted">g</listItem>' +
-				'<listItem indent="1" type="numbered">h</listItem>' +
-				'<listItem indent="1" type="numbered">i</listItem>',
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'[<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="numbered">e</listItem>]' +
+				'<listItem listIndent="1" listType="numbered">f</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">g</listItem>' +
+				'<listItem listIndent="1" listType="numbered">h</listItem>' +
+				'<listItem listIndent="1" listType="numbered">i</listItem>',
 
 				8,
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="1" type="bulleted">f</listItem>' +
-				'<listItem indent="0" type="bulleted">g</listItem>' +
-				'<listItem indent="1" type="numbered">h</listItem>' +
-				'<listItem indent="1" type="numbered">c</listItem>' +
-				'<listItem indent="0" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="numbered">e</listItem>' +
-				'<listItem indent="1" type="numbered">i</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">g</listItem>' +
+				'<listItem listIndent="1" listType="numbered">h</listItem>' +
+				'<listItem listIndent="1" listType="numbered">c</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="numbered">e</listItem>' +
+				'<listItem listIndent="1" listType="numbered">i</listItem>'
 			);
 
 			test(
 				'multiple nested list items of different types #2 - fix at end',
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'[<listItem indent="1" type="bulleted">c</listItem>' +
-				'<listItem indent="0" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="numbered">e</listItem>]' +
-				'<listItem indent="1" type="numbered">f</listItem>' +
-				'<listItem indent="0" type="bulleted">g</listItem>' +
-				'<listItem indent="1" type="bulleted">h</listItem>' +
-				'<listItem indent="1" type="bulleted">i</listItem>',
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'[<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="numbered">e</listItem>]' +
+				'<listItem listIndent="1" listType="numbered">f</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">g</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">h</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">i</listItem>',
 
 				8,
 
-				'<listItem indent="0" type="bulleted">a</listItem>' +
-				'<listItem indent="1" type="bulleted">b</listItem>' +
-				'<listItem indent="1" type="bulleted">f</listItem>' +
-				'<listItem indent="0" type="bulleted">g</listItem>' +
-				'<listItem indent="1" type="bulleted">h</listItem>' +
-				'<listItem indent="1" type="bulleted">c</listItem>' +
-				'<listItem indent="0" type="bulleted">d</listItem>' +
-				'<listItem indent="1" type="numbered">e</listItem>' +
-				'<listItem indent="1" type="numbered">i</listItem>'
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">g</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">h</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+				'<listItem listIndent="1" listType="numbered">e</listItem>' +
+				'<listItem listIndent="1" listType="numbered">i</listItem>'
 			);
 
 			// #78.
@@ -3226,21 +3233,21 @@ describe( 'ListEditing', () => {
 				'move out of container',
 
 				'<blockQuote>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
-					'[<listItem indent="2" type="bulleted">e</listItem>]' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">d</listItem>' +
+				'[<listItem listIndent="2" listType="bulleted">e</listItem>]' +
 				'</blockQuote>',
 
 				0,
 
-				'<listItem indent="0" type="bulleted">e</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">e</listItem>' +
 				'<blockQuote>' +
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'<listItem indent="1" type="bulleted">c</listItem>' +
-					'<listItem indent="1" type="bulleted">d</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">c</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">d</listItem>' +
 				'</blockQuote>'
 			);
 		} );
@@ -3248,26 +3255,26 @@ describe( 'ListEditing', () => {
 		describe( 'rename', () => {
 			it( 'rename nested item', () => {
 				const modelBefore =
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
-					'[<listItem indent="2" type="bulleted">c</listItem>]' +
-					'<listItem indent="2" type="bulleted">d</listItem>' +
-					'<listItem indent="3" type="bulleted">e</listItem>' +
-					'<listItem indent="1" type="bulleted">f</listItem>' +
-					'<listItem indent="2" type="bulleted">g</listItem>' +
-					'<listItem indent="1" type="bulleted">h</listItem>' +
-					'<listItem indent="2" type="bulleted">i</listItem>';
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
+					'[<listItem listIndent="2" listType="bulleted">c</listItem>]' +
+					'<listItem listIndent="2" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="3" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">g</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">h</listItem>' +
+					'<listItem listIndent="2" listType="bulleted">i</listItem>';
 
 				const expectedModel =
-					'<listItem indent="0" type="bulleted">a</listItem>' +
-					'<listItem indent="1" type="bulleted">b</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">a</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">b</listItem>' +
 					'<paragraph>c</paragraph>' +
-					'<listItem indent="0" type="bulleted">d</listItem>' +
-					'<listItem indent="1" type="bulleted">e</listItem>' +
-					'<listItem indent="0" type="bulleted">f</listItem>' +
-					'<listItem indent="1" type="bulleted">g</listItem>' +
-					'<listItem indent="0" type="bulleted">h</listItem>' +
-					'<listItem indent="1" type="bulleted">i</listItem>';
+					'<listItem listIndent="0" listType="bulleted">d</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">e</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">f</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">g</listItem>' +
+					'<listItem listIndent="0" listType="bulleted">h</listItem>' +
+					'<listItem listIndent="1" listType="bulleted">i</listItem>';
 
 				setModelData( model, modelBefore );
 
@@ -3285,54 +3292,54 @@ describe( 'ListEditing', () => {
 	describe( 'paste and insertContent integration', () => {
 		it( 'should be triggered on DataController#insertContent()', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B[]</listItem>' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			editor.model.insertContent(
 				parseModel(
-					'<listItem type="bulleted" indent="0">X</listItem>' +
-					'<listItem type="bulleted" indent="1">Y</listItem>',
+					'<listItem listType="bulleted" listIndent="0">X</listItem>' +
+					'<listItem listType="bulleted" listIndent="1">Y</listItem>',
 					model.schema
 				),
 				modelDoc.selection
 			);
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">BX</listItem>' +
-				'<listItem indent="2" type="bulleted">Y[]</listItem>' +
-				'<listItem indent="2" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">BX</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		// Just checking that it doesn't crash. #69
 		it( 'should work if an element is passed to DataController#insertContent()', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B[]</listItem>' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			editor.model.insertContent(
-				new ModelElement( 'listItem', { type: 'bulleted', indent: '0' }, 'X' ),
+				new ModelElement( 'listItem', { listType: 'bulleted', listIndent: '0' }, 'X' ),
 				modelDoc.selection
 			);
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">BX[]</listItem>' +
-				'<listItem indent="2" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">BX[]</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		// Just checking that it doesn't crash. #69
 		it( 'should work if an element is passed to DataController#insertContent()', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B[]</listItem>' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			editor.model.insertContent(
@@ -3341,17 +3348,17 @@ describe( 'ListEditing', () => {
 			);
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">BX[]</listItem>' +
-				'<listItem indent="2" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">BX[]</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		it( 'should fix indents of pasted list items', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B[]</listItem>' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			const clipboard = editor.plugins.get( 'Clipboard' );
@@ -3361,18 +3368,18 @@ describe( 'ListEditing', () => {
 			} );
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">BX</listItem>' +
-				'<listItem indent="2" type="bulleted">Y[]</listItem>' +
-				'<listItem indent="2" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">BX</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		it( 'should not fix indents of list items that are separated by non-list element', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B[]</listItem>' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			const clipboard = editor.plugins.get( 'Clipboard' );
@@ -3382,20 +3389,20 @@ describe( 'ListEditing', () => {
 			} );
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">BW</listItem>' +
-				'<listItem indent="2" type="bulleted">X</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">BW</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">X</listItem>' +
 				'<paragraph>Y</paragraph>' +
-				'<listItem indent="0" type="bulleted">Z[]</listItem>' +
-				'<listItem indent="1" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">Z[]</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		it( 'should co-work correctly with post fixer', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B[]</listItem>' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			const clipboard = editor.plugins.get( 'Clipboard' );
@@ -3405,18 +3412,18 @@ describe( 'ListEditing', () => {
 			} );
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">BX</listItem>' +
-				'<listItem indent="0" type="bulleted">Y[]</listItem>' +
-				'<listItem indent="1" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">BX</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		it( 'should work if items are pasted between listItem elements', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A</listItem>' +
-				'<listItem type="bulleted" indent="1">B</listItem>[]' +
-				'<listItem type="bulleted" indent="2">C</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B</listItem>[]' +
+				'<listItem listType="bulleted" listIndent="2">C</listItem>'
 			);
 
 			const clipboard = editor.plugins.get( 'Clipboard' );
@@ -3426,18 +3433,18 @@ describe( 'ListEditing', () => {
 			} );
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">A</listItem>' +
-				'<listItem indent="1" type="bulleted">B</listItem>' +
-				'<listItem indent="1" type="bulleted">X</listItem>' +
-				'<listItem indent="2" type="bulleted">Y[]</listItem>' +
-				'<listItem indent="2" type="bulleted">C</listItem>'
+				'<listItem listIndent="0" listType="bulleted">A</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">B</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">X</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">C</listItem>'
 			);
 		} );
 
 		it( 'should create correct model when list items are pasted in top-level list', () => {
 			setModelData( model,
-				'<listItem type="bulleted" indent="0">A[]</listItem>' +
-				'<listItem type="bulleted" indent="1">B</listItem>'
+				'<listItem listType="bulleted" listIndent="0">A[]</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">B</listItem>'
 			);
 
 			const clipboard = editor.plugins.get( 'Clipboard' );
@@ -3447,9 +3454,9 @@ describe( 'ListEditing', () => {
 			} );
 
 			expect( getModelData( model ) ).to.equal(
-				'<listItem indent="0" type="bulleted">AX</listItem>' +
-				'<listItem indent="1" type="bulleted">Y[]</listItem>' +
-				'<listItem indent="1" type="bulleted">B</listItem>'
+				'<listItem listIndent="0" listType="bulleted">AX</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="1" listType="bulleted">B</listItem>'
 			);
 		} );
 
@@ -3467,7 +3474,7 @@ describe( 'ListEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>AX</paragraph>' +
-				'<listItem indent="0" type="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">Y[]</listItem>' +
 				'<paragraph>B</paragraph>'
 			);
 		} );
@@ -3483,8 +3490,8 @@ describe( 'ListEditing', () => {
 		it( 'should correctly handle item that is pasted without its parent', () => {
 			setModelData( model,
 				'<paragraph>Foo</paragraph>' +
-				'<listItem type="numbered" indent="0">A</listItem>' +
-				'<listItem type="numbered" indent="1">B</listItem>' +
+				'<listItem listType="numbered" listIndent="0">A</listItem>' +
+				'<listItem listType="numbered" listIndent="1">B</listItem>' +
 				'[]' +
 				'<paragraph>Bar</paragraph>'
 			);
@@ -3497,9 +3504,9 @@ describe( 'ListEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>Foo</paragraph>' +
-				'<listItem indent="0" type="numbered">A</listItem>' +
-				'<listItem indent="1" type="numbered">B</listItem>' +
-				'<listItem indent="1" type="numbered">X[]</listItem>' +
+				'<listItem listIndent="0" listType="numbered">A</listItem>' +
+				'<listItem listIndent="1" listType="numbered">B</listItem>' +
+				'<listItem listIndent="1" listType="numbered">X[]</listItem>' +
 				'<paragraph>Bar</paragraph>'
 			);
 		} );
@@ -3507,8 +3514,8 @@ describe( 'ListEditing', () => {
 		it( 'should correctly handle item that is pasted without its parent #2', () => {
 			setModelData( model,
 				'<paragraph>Foo</paragraph>' +
-				'<listItem type="numbered" indent="0">A</listItem>' +
-				'<listItem type="numbered" indent="1">B</listItem>' +
+				'<listItem listType="numbered" listIndent="0">A</listItem>' +
+				'<listItem listType="numbered" listIndent="1">B</listItem>' +
 				'[]' +
 				'<paragraph>Bar</paragraph>'
 			);
@@ -3521,10 +3528,10 @@ describe( 'ListEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>Foo</paragraph>' +
-				'<listItem indent="0" type="numbered">A</listItem>' +
-				'<listItem indent="1" type="numbered">B</listItem>' +
-				'<listItem indent="1" type="numbered">X</listItem>' +
-				'<listItem indent="2" type="bulleted">Y[]</listItem>' +
+				'<listItem listIndent="0" listType="numbered">A</listItem>' +
+				'<listItem listIndent="1" listType="numbered">B</listItem>' +
+				'<listItem listIndent="1" listType="numbered">X</listItem>' +
+				'<listItem listIndent="2" listType="bulleted">Y[]</listItem>' +
 				'<paragraph>Bar</paragraph>'
 			);
 		} );
@@ -3533,8 +3540,8 @@ describe( 'ListEditing', () => {
 	describe( 'other', () => {
 		it( 'model insert converter should not fire if change was already consumed', () => {
 			editor.editing.downcastDispatcher.on( 'insert:listItem', ( evt, data, conversionApi ) => {
-				conversionApi.consumable.consume( data.item, 'attribute:type' );
-				conversionApi.consumable.consume( data.item, 'attribute:indent' );
+				conversionApi.consumable.consume( data.item, 'attribute:listType' );
+				conversionApi.consumable.consume( data.item, 'attribute:listIndent' );
 
 				const converter = insertElement( ( modelElement, viewWriter ) => viewWriter.createContainerElement( 'p' ) );
 
@@ -3542,7 +3549,7 @@ describe( 'ListEditing', () => {
 			}, { priority: 'highest' } );
 
 			// Paragraph is needed, otherwise selection throws.
-			setModelData( model, '<paragraph>x</paragraph><listItem indent="0" type="bulleted">y</listItem>' );
+			setModelData( model, '<paragraph>x</paragraph><listItem listIndent="0" listType="bulleted">y</listItem>' );
 
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<p>x</p><p>y</p>' );
 		} );
@@ -3553,7 +3560,7 @@ describe( 'ListEditing', () => {
 			}, { priority: 'highest' } );
 
 			// Paragraph is needed to prevent autoparagraphing of empty editor.
-			setModelData( model, '<paragraph>x</paragraph><listItem indent="0" type="bulleted"></listItem>' );
+			setModelData( model, '<paragraph>x</paragraph><listItem listIndent="0" listType="bulleted"></listItem>' );
 
 			model.change( writer => {
 				writer.remove( modelRoot.getChild( 1 ) );
@@ -3563,28 +3570,31 @@ describe( 'ListEditing', () => {
 		} );
 
 		it( 'model change type converter should not fire if change was already consumed', () => {
-			editor.editing.downcastDispatcher.on( 'attribute:type', ( evt, data, conversionApi ) => {
-				conversionApi.consumable.consume( data.item, 'attribute:type' );
+			editor.editing.downcastDispatcher.on( 'attribute:listType', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item, 'attribute:listType' );
 			}, { priority: 'highest' } );
 
-			setModelData( model, '<listItem indent="0" type="bulleted"></listItem>' );
+			setModelData( model, '<listItem listIndent="0" listType="bulleted"></listItem>' );
 
 			model.change( writer => {
-				writer.setAttribute( 'type', 'numbered', modelRoot.getChild( 0 ) );
+				writer.setAttribute( 'listType', 'numbered', modelRoot.getChild( 0 ) );
 			} );
 
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<ul><li></li></ul>' );
 		} );
 
 		it( 'model change indent converter should not fire if change was already consumed', () => {
-			editor.editing.downcastDispatcher.on( 'attribute:indent', ( evt, data, conversionApi ) => {
-				conversionApi.consumable.consume( data.item, 'attribute:indent' );
+			editor.editing.downcastDispatcher.on( 'attribute:listIndent', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item, 'attribute:listIndent' );
 			}, { priority: 'highest' } );
 
-			setModelData( model, '<listItem indent="0" type="bulleted">a</listItem><listItem indent="0" type="bulleted">b</listItem>' );
+			setModelData(
+				model,
+				'<listItem listIndent="0" listType="bulleted">a</listItem><listItem listIndent="0" listType="bulleted">b</listItem>'
+			);
 
 			model.change( writer => {
-				writer.setAttribute( 'indent', 1, modelRoot.getChild( 1 ) );
+				writer.setAttribute( 'listIndent', 1, modelRoot.getChild( 1 ) );
 			} );
 
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( '<ul><li>a</li><li>b</li></ul>' );
@@ -3636,7 +3646,7 @@ describe( 'ListEditing', () => {
 
 			model.change( writer => {
 				// Change indent of the second list item.
-				writer.setAttribute( 'indent', 1, modelRoot.getChild( 1 ) );
+				writer.setAttribute( 'listIndent', 1, modelRoot.getChild( 1 ) );
 			} );
 
 			// Check if the new <ul> was added at correct position.
@@ -3760,7 +3770,7 @@ describe( 'ListEditing', () => {
 
 			expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 				'<div>abc</div>' +
-				'<listItem indent="0" type="bulleted">foo</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">foo</listItem>' +
 				'<div>def</div>'
 			);
 		} );
@@ -3780,7 +3790,7 @@ describe( 'ListEditing', () => {
 
 			expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 				'<div>abc</div>' +
-				'<listItem indent="0" type="bulleted">foo</listItem>'
+				'<listItem listIndent="0" listType="bulleted">foo</listItem>'
 			);
 		} );
 
@@ -3798,7 +3808,7 @@ describe( 'ListEditing', () => {
 			);
 
 			expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-				'<listItem indent="0" type="bulleted">foo</listItem>' +
+				'<listItem listIndent="0" listType="bulleted">foo</listItem>' +
 				'<div>def</div>'
 			);
 		} );
@@ -3856,13 +3866,13 @@ describe( 'ListEditing', () => {
 	function testChangeType( testName, input, output ) {
 		const actionCallback = () => {
 			const element = modelDoc.selection.getFirstPosition().nodeAfter;
-			const newType = element.getAttribute( 'type' ) == 'numbered' ? 'bulleted' : 'numbered';
+			const newType = element.getAttribute( 'listType' ) == 'numbered' ? 'bulleted' : 'numbered';
 
 			model.change( writer => {
 				const itemsToChange = Array.from( modelDoc.selection.getSelectedBlocks() );
 
 				for ( const item of itemsToChange ) {
-					writer.setAttribute( 'type', newType, item );
+					writer.setAttribute( 'listType', newType, item );
 				}
 			} );
 		};
@@ -3876,8 +3886,8 @@ describe( 'ListEditing', () => {
 
 			model.change( writer => {
 				writer.rename( element, 'paragraph' );
-				writer.removeAttribute( 'type', element );
-				writer.removeAttribute( 'indent', element );
+				writer.removeAttribute( 'listType', element );
+				writer.removeAttribute( 'listIndent', element );
 			} );
 		};
 
@@ -3889,7 +3899,7 @@ describe( 'ListEditing', () => {
 			const element = modelDoc.selection.getFirstPosition().nodeAfter;
 
 			model.change( writer => {
-				writer.setAttributes( { type: 'bulleted', indent: newIndent }, element );
+				writer.setAttributes( { listType: 'bulleted', listIndent: newIndent }, element );
 				writer.rename( element, 'listItem' );
 			} );
 		};
@@ -3900,7 +3910,7 @@ describe( 'ListEditing', () => {
 	function testChangeIndent( testName, newIndent, input, output ) {
 		const actionCallback = () => {
 			model.change( writer => {
-				writer.setAttribute( 'indent', newIndent, modelDoc.selection.getFirstRange() );
+				writer.setAttribute( 'listIndent', newIndent, modelDoc.selection.getFirstRange() );
 			} );
 		};
 

--- a/tests/listui.js
+++ b/tests/listui.js
@@ -55,7 +55,7 @@ describe( 'ListUI', () => {
 	} );
 
 	it( 'should bind bulleted list button model to bulledList command', () => {
-		setData( model, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+		setData( model, '<listItem listType="bulleted" listIndent="0">[]foo</listItem>' );
 
 		const command = editor.commands.get( 'bulletedList' );
 
@@ -70,7 +70,7 @@ describe( 'ListUI', () => {
 	} );
 
 	it( 'should bind numbered list button model to numberedList command', () => {
-		setData( model, '<listItem type="bulleted" indent="0">[]foo</listItem>' );
+		setData( model, '<listItem listType="bulleted" listIndent="0">[]foo</listItem>' );
 
 		const command = editor.commands.get( 'numberedList' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Rename list attributes `indent` and `type` to `listIndent` and `listType`. Closes ckeditor/ckeditor5#3003.

BREAKING CHANGE: The `indent` attribute is now called `listIndent`. See ckeditor/ckeditor5#3003 for more information.
BREAKING CHANGE: The `type` attribute is now called `listType`. See ckeditor/ckeditor5#3003 for more information.

---

### Additional information

* It addresses the issue with `<video type="">` issue. But it should be fixed by schema itself.
* Requires changes in other repos:
    * https://github.com/ckeditor/ckeditor5-alignment/tree/t/ckeditor5-list/103
    * https://github.com/ckeditor/ckeditor5-autoformat/tree/t/ckeditor5-list/103
    * https://github.com/ckeditor/ckeditor5-block-quote/tree/t/ckeditor5-list/103
    * https://github.com/ckeditor/ckeditor5-engine/tree/t/ckeditor5-list/103
    * https://github.com/ckeditor/ckeditor5-typing/tree/t/ckeditor5-list/103
