### PR TITLE
T/ckeditor5 engine/1555

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^11.0.1",
-    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-paragraph": "^10.0.3",
     "@ckeditor/ckeditor5-ui": "^11.1.0",
     "@ckeditor/ckeditor5-utils": "^11.0.0"
@@ -21,6 +20,7 @@
     "@ckeditor/ckeditor5-block-quote": "^10.1.0",
     "@ckeditor/ckeditor5-clipboard": "^10.0.3",
     "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
+    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-enter": "^10.1.2",
     "@ckeditor/ckeditor5-heading": "^10.1.0",
     "@ckeditor/ckeditor5-link": "^10.0.4",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
+    "@ckeditor/ckeditor5-core": "^11.0.1",
     "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-paragraph": "^10.0.3",
-    "@ckeditor/ckeditor5-core": "^11.0.1",
     "@ckeditor/ckeditor5-ui": "^11.1.0",
     "@ckeditor/ckeditor5-utils": "^11.0.0"
   },

--- a/src/listediting.js
+++ b/src/listediting.js
@@ -69,22 +69,22 @@ export default class ListEditing extends Plugin {
 		data.mapper.registerViewToModelLength( 'li', getViewListItemLength );
 
 		editing.mapper.on( 'modelToViewPosition', modelToViewPosition );
-		editing.mapper.on( 'viewToModelPosition', viewToModelPosition );
+		editing.mapper.on( 'viewToModelPosition', viewToModelPosition( editor.model ) );
 		data.mapper.on( 'modelToViewPosition', modelToViewPosition );
 
 		editing.downcastDispatcher.on( 'insert', modelViewSplitOnInsert, { priority: 'high' } );
-		editing.downcastDispatcher.on( 'insert:listItem', modelViewInsertion );
+		editing.downcastDispatcher.on( 'insert:listItem', modelViewInsertion( editor.model ) );
 		data.downcastDispatcher.on( 'insert', modelViewSplitOnInsert, { priority: 'high' } );
-		data.downcastDispatcher.on( 'insert:listItem', modelViewInsertion );
+		data.downcastDispatcher.on( 'insert:listItem', modelViewInsertion( editor.model ) );
 
 		editing.downcastDispatcher.on( 'attribute:listType:listItem', modelViewChangeType );
 		data.downcastDispatcher.on( 'attribute:listType:listItem', modelViewChangeType );
-		editing.downcastDispatcher.on( 'attribute:listIndent:listItem', modelViewChangeIndent );
-		data.downcastDispatcher.on( 'attribute:listIndent:listItem', modelViewChangeIndent );
+		editing.downcastDispatcher.on( 'attribute:listIndent:listItem', modelViewChangeIndent( editor.model ) );
+		data.downcastDispatcher.on( 'attribute:listIndent:listItem', modelViewChangeIndent( editor.model ) );
 
-		editing.downcastDispatcher.on( 'remove:listItem', modelViewRemove );
+		editing.downcastDispatcher.on( 'remove:listItem', modelViewRemove( editor.model ) );
 		editing.downcastDispatcher.on( 'remove', modelViewMergeAfter, { priority: 'low' } );
-		data.downcastDispatcher.on( 'remove:listItem', modelViewRemove );
+		data.downcastDispatcher.on( 'remove:listItem', modelViewRemove( editor.model ) );
 		data.downcastDispatcher.on( 'remove', modelViewMergeAfter, { priority: 'low' } );
 
 		data.upcastDispatcher.on( 'element:ul', cleanList, { priority: 'high' } );

--- a/src/listediting.js
+++ b/src/listediting.js
@@ -68,9 +68,9 @@ export default class ListEditing extends Plugin {
 		editing.mapper.registerViewToModelLength( 'li', getViewListItemLength );
 		data.mapper.registerViewToModelLength( 'li', getViewListItemLength );
 
-		editing.mapper.on( 'modelToViewPosition', modelToViewPosition );
+		editing.mapper.on( 'modelToViewPosition', modelToViewPosition( editing.view ) );
 		editing.mapper.on( 'viewToModelPosition', viewToModelPosition( editor.model ) );
-		data.mapper.on( 'modelToViewPosition', modelToViewPosition );
+		data.mapper.on( 'modelToViewPosition', modelToViewPosition( editing.view ) );
 
 		editing.downcastDispatcher.on( 'insert', modelViewSplitOnInsert, { priority: 'high' } );
 		editing.downcastDispatcher.on( 'insert:listItem', modelViewInsertion( editor.model ) );

--- a/tests/indentcommand.js
+++ b/tests/indentcommand.js
@@ -6,8 +6,6 @@
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import Model from '@ckeditor/ckeditor5-engine/src/model/model';
 import IndentCommand from '../src/indentcommand';
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
-import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'IndentCommand', () => {
@@ -177,9 +175,9 @@ describe( 'IndentCommand', () => {
 
 			it( 'should increment indent of all selected item when multiple items are selected', () => {
 				model.change( writer => {
-					writer.setSelection( new Range(
-						new Position( root.getChild( 1 ), [ 0 ] ),
-						new Position( root.getChild( 3 ), [ 1 ] )
+					writer.setSelection( writer.createRange(
+						writer.createPositionFromPath( root.getChild( 1 ), [ 0 ] ),
+						writer.createPositionFromPath( root.getChild( 3 ), [ 1 ] )
 					) );
 				} );
 
@@ -294,9 +292,9 @@ describe( 'IndentCommand', () => {
 
 			it( 'should outdent all selected item when multiple items are selected', () => {
 				model.change( writer => {
-					writer.setSelection( new Range(
-						new Position( root.getChild( 1 ), [ 0 ] ),
-						new Position( root.getChild( 3 ), [ 1 ] )
+					writer.setSelection( writer.createRange(
+						writer.createPositionFromPath( root.getChild( 1 ), [ 0 ] ),
+						writer.createPositionFromPath( root.getChild( 3 ), [ 1 ] )
 					) );
 				} );
 

--- a/tests/listcommand.js
+++ b/tests/listcommand.js
@@ -6,8 +6,6 @@
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import Model from '@ckeditor/ckeditor5-engine/src/model/model';
 import ListCommand from '../src/listcommand';
-import Range from '@ckeditor/ckeditor5-engine/src/model/range';
-import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'ListCommand', () => {
@@ -306,9 +304,9 @@ describe( 'ListCommand', () => {
 					// From first paragraph to second paragraph.
 					// Command value=false, we are turning on list items.
 					model.change( writer => {
-						writer.setSelection( new Range(
-							Position.createAt( root.getChild( 2 ), 0 ),
-							Position.createAt( root.getChild( 3 ), 'end' )
+						writer.setSelection( writer.createRange(
+							writer.createPositionAt( root.getChild( 2 ), 0 ),
+							writer.createPositionAt( root.getChild( 3 ), 'end' )
 						) );
 					} );
 
@@ -331,9 +329,9 @@ describe( 'ListCommand', () => {
 					// From second bullet list item to first numbered list item.
 					// Command value=true, we are turning off list items.
 					model.change( writer => {
-						writer.setSelection( new Range(
-							Position.createAt( root.getChild( 1 ), 0 ),
-							Position.createAt( root.getChild( 4 ), 'end' )
+						writer.setSelection( writer.createRange(
+							writer.createPositionAt( root.getChild( 1 ), 0 ),
+							writer.createPositionAt( root.getChild( 4 ), 'end' )
 						) );
 					} );
 
@@ -356,9 +354,9 @@ describe( 'ListCommand', () => {
 				it( 'should change closest listItem\'s type', () => {
 					// From first numbered lsit item to third bulleted list item.
 					model.change( writer => {
-						writer.setSelection( new Range(
-							Position.createAt( root.getChild( 4 ), 0 ),
-							Position.createAt( root.getChild( 6 ), 0 )
+						writer.setSelection( writer.createRange(
+							writer.createPositionAt( root.getChild( 4 ), 0 ),
+							writer.createPositionAt( root.getChild( 6 ), 0 )
 						) );
 					} );
 
@@ -381,9 +379,9 @@ describe( 'ListCommand', () => {
 				it( 'should handle outdenting sub-items when list item is turned off', () => {
 					// From first numbered list item to third bulleted list item.
 					model.change( writer => {
-						writer.setSelection( new Range(
-							Position.createAt( root.getChild( 1 ), 0 ),
-							Position.createAt( root.getChild( 5 ), 'end' )
+						writer.setSelection( writer.createRange(
+							writer.createPositionAt( root.getChild( 1 ), 0 ),
+							writer.createPositionAt( root.getChild( 5 ), 'end' )
 						) );
 					} );
 

--- a/tests/listediting.js
+++ b/tests/listediting.js
@@ -7,8 +7,6 @@ import ListEditing from '../src/listediting';
 import ListCommand from '../src/listcommand';
 
 import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
-import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
-import ViewUIElement from '@ckeditor/ckeditor5-engine/src/view/uielement';
 
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
@@ -396,7 +394,7 @@ describe( 'ListEditing', () => {
 			describe( 'view to model', () => {
 				function test( testName, viewPath, modelPath ) {
 					it( testName, () => {
-						const viewPos = getViewPosition( viewRoot, viewPath );
+						const viewPos = getViewPosition( viewRoot, viewPath, view );
 						const modelPos = mapper.toModelPosition( viewPos );
 
 						expect( modelPos.root ).to.equal( modelRoot );
@@ -1374,7 +1372,7 @@ describe( 'ListEditing', () => {
 			describe( 'view to model', () => {
 				function test( testName, viewPath, modelPath ) {
 					it( testName, () => {
-						const viewPos = getViewPosition( viewRoot, viewPath );
+						const viewPos = getViewPosition( viewRoot, viewPath, view );
 						const modelPos = mapper.toModelPosition( viewPos );
 
 						expect( modelPos.root ).to.equal( modelRoot );
@@ -3675,13 +3673,12 @@ describe( 'ListEditing', () => {
 		it( 'ul and ol should not be inserted before ui element - injectViewList()', () => {
 			editor.setData( '<ul><li>Foo</li><li>Bar</li></ul>' );
 
-			const uiElement = new ViewUIElement( 'span' );
-
 			// Append ui element at the end of first <li>.
 			view.change( writer => {
 				const firstChild = viewDoc.getRoot().getChild( 0 ).getChild( 0 );
 
-				writer.insert( ViewPosition.createAt( firstChild, 'end' ), uiElement );
+				const uiElement = writer.createUIElement( 'span' );
+				writer.insert( writer.createPositionAt( firstChild, 'end' ), uiElement );
 			} );
 
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
@@ -3701,13 +3698,12 @@ describe( 'ListEditing', () => {
 		it( 'ul and ol should not be inserted before ui element - hoistNestedLists()', () => {
 			editor.setData( '<ul><li>Foo</li><li>Bar<ul><li>Xxx</li><li>Yyy</li></ul></li></ul>' );
 
-			const uiElement = new ViewUIElement( 'span' );
-
 			// Append ui element at the end of first <li>.
 			view.change( writer => {
 				const firstChild = viewDoc.getRoot().getChild( 0 ).getChild( 0 );
 
-				writer.insert( ViewPosition.createAt( firstChild, 'end' ), uiElement );
+				const uiElement = writer.createUIElement( 'span' );
+				writer.insert( writer.createPositionAt( firstChild, 'end' ), uiElement );
 			} );
 
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
@@ -3724,20 +3720,18 @@ describe( 'ListEditing', () => {
 		} );
 
 		describe( 'remove converter should properly handle ui elements', () => {
-			let uiElement, liFoo, liBar;
+			let liFoo, liBar;
 
 			beforeEach( () => {
 				editor.setData( '<ul><li>Foo</li><li>Bar</li></ul>' );
 				liFoo = modelRoot.getChild( 0 );
 				liBar = modelRoot.getChild( 1 );
-
-				uiElement = new ViewUIElement( 'span' );
 			} );
 
 			it( 'ui element before <ul>', () => {
 				view.change( writer => {
 					// Append ui element before <ul>.
-					writer.insert( ViewPosition.createAt( viewRoot, 0 ), uiElement );
+					writer.insert( writer.createPositionAt( viewRoot, 0 ), writer.createUIElement( 'span' ) );
 				} );
 
 				model.change( writer => {
@@ -3751,7 +3745,7 @@ describe( 'ListEditing', () => {
 			it( 'ui element before first <li>', () => {
 				view.change( writer => {
 					// Append ui element before <ul>.
-					writer.insert( ViewPosition.createAt( viewRoot.getChild( 0 ), 0 ), uiElement );
+					writer.insert( writer.createPositionAt( viewRoot.getChild( 0 ), 0 ), writer.createUIElement( 'span' ) );
 				} );
 
 				model.change( writer => {
@@ -3765,7 +3759,7 @@ describe( 'ListEditing', () => {
 			it( 'ui element in the middle of list', () => {
 				view.change( writer => {
 					// Append ui element before <ul>.
-					writer.insert( ViewPosition.createAt( viewRoot.getChild( 0 ), 'end' ), uiElement );
+					writer.insert( writer.createPositionAt( viewRoot.getChild( 0 ), 'end' ), writer.createUIElement( 'span' ) );
 				} );
 
 				model.change( writer => {
@@ -3857,14 +3851,14 @@ describe( 'ListEditing', () => {
 		} );
 	} );
 
-	function getViewPosition( root, path ) {
+	function getViewPosition( root, path, view ) {
 		let parent = root;
 
 		while ( path.length > 1 ) {
 			parent = parent.getChild( path.shift() );
 		}
 
-		return new ViewPosition( parent, path[ 0 ] );
+		return view.createPositionAt( parent, path[ 0 ] );
 	}
 
 	function getViewPath( position ) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -4,7 +4,6 @@
  */
 
 import ViewContainerElement from '@ckeditor/ckeditor5-engine/src/view/containerelement';
-import ViewPosition from '@ckeditor/ckeditor5-engine/src/view/position';
 import ViewDowncastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwriter';
 import { createViewListItemElement } from '../src/utils';
 
@@ -39,23 +38,23 @@ describe( 'utils', () => {
 				const innerListItem1 = createViewListItemElement( writer );
 
 				writer.insert(
-					ViewPosition.createAt( innerListItem1, 0 ),
+					writer.createPositionAt( innerListItem1, 0 ),
 					writer.createText( 'foo' )
 				);
 
 				const innerListItem2 = createViewListItemElement( writer );
 
 				writer.insert(
-					ViewPosition.createAt( innerListItem2, 0 ),
+					writer.createPositionAt( innerListItem2, 0 ),
 					writer.createText( 'bar' )
 				);
 
 				const innerList = writer.createContainerElement( 'ul' );
-				writer.insert( ViewPosition.createAt( innerList, 0 ), innerListItem1 );
-				writer.insert( ViewPosition.createAt( innerList, 0 ), innerListItem2 );
+				writer.insert( writer.createPositionAt( innerList, 0 ), innerListItem1 );
+				writer.insert( writer.createPositionAt( innerList, 0 ), innerListItem2 );
 
 				const outerListItem = createViewListItemElement( writer );
-				writer.insert( ViewPosition.createAt( outerListItem, 0 ), innerList );
+				writer.insert( writer.createPositionAt( outerListItem, 0 ), innerList );
 
 				expect( outerListItem.getFillerOffset() ).to.equal( 0 );
 			} );
@@ -64,7 +63,7 @@ describe( 'utils', () => {
 				const item = createViewListItemElement( writer );
 
 				writer.insert(
-					ViewPosition.createAt( item, 0 ),
+					writer.createPositionAt( item, 0 ),
 					writer.createText( 'foo' )
 				);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove Position, Range, Selection imports from engine/model and engine/view.

BREAKING CHANGE: The `modelViewInsertion()` converter now returns converter callback and requires model instance as a parameter.
BREAKING CHANGE: The `modelViewRemove()` converter now returns converter callback and requires model instance as a parameter.
BREAKING CHANGE: The `modelViewChangeIndent()` converter now returns converter callback and requires model instance as a parameter.
BREAKING CHANGE: The `viewToModelPosition()` converter now returns converter callback and requires model instance as a parameter.
BREAKING CHANGE: The `modelToViewPosition()` converter now returns converter callback and requires view instance as a parameter.

---

### Additional information

* Part of: https://github.com/ckeditor/ckeditor5-engine/pull/1585.
