### PR TITLE
Soft break inside list element will be handled correctly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^11.0.1",
+    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-paragraph": "^10.0.3",
     "@ckeditor/ckeditor5-ui": "^11.1.0",
     "@ckeditor/ckeditor5-utils": "^11.0.0"
@@ -20,7 +21,6 @@
     "@ckeditor/ckeditor5-block-quote": "^10.1.0",
     "@ckeditor/ckeditor5-clipboard": "^10.0.3",
     "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
-    "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-enter": "^10.1.2",
     "@ckeditor/ckeditor5-heading": "^10.1.0",
     "@ckeditor/ckeditor5-link": "^10.0.4",

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,5 +26,18 @@ export function createViewListItemElement( writer ) {
 function getFillerOffset() {
 	const hasOnlyLists = !this.isEmpty && ( this.getChild( 0 ).name == 'ul' || this.getChild( 0 ).name == 'ol' );
 
-	return this.isEmpty || hasOnlyLists ? 0 : null;
+	if ( this.isEmpty || hasOnlyLists ) {
+		return 0;
+	}
+
+	const children = [ ...this.getChildren() ];
+	const lastChild = children[ this.childCount - 1 ];
+
+	// Block filler is required after a `<br>` if it's the last element in its container.
+	// See: https://github.com/ckeditor/ckeditor5/issues/1312#issuecomment-436669045.
+	if ( lastChild && lastChild.is( 'element', 'br' ) ) {
+		return this.childCount;
+	}
+
+	return null;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,7 @@ export function createViewListItemElement( writer ) {
 // Implementation of getFillerOffset for view list item element.
 //
 // @returns {Number|null} Block filler offset or `null` if block filler is not needed.
-function _getFillerOffset() {
+function getListItemFillerOffset() {
 	const hasOnlyLists = !this.isEmpty && ( this.getChild( 0 ).name == 'ul' || this.getChild( 0 ).name == 'ol' );
 
 	if ( this.isEmpty || hasOnlyLists ) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ import { getFillerOffset } from '@ckeditor/ckeditor5-engine/src/view/containerel
  */
 export function createViewListItemElement( writer ) {
 	const viewItem = writer.createContainerElement( 'li' );
-	viewItem.getFillerOffset = _getFillerOffset;
+	viewItem.getFillerOffset = getListItemFillerOffset;
 
 	return viewItem;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,8 @@
  * @module list/utils
  */
 
+import { getFillerOffset } from '@ckeditor/ckeditor5-engine/src/view/containerelement';
+
 /**
  * Creates list item {@link module:engine/view/containerelement~ContainerElement}.
  *
@@ -15,7 +17,7 @@
  */
 export function createViewListItemElement( writer ) {
 	const viewItem = writer.createContainerElement( 'li' );
-	viewItem.getFillerOffset = getFillerOffset;
+	viewItem.getFillerOffset = _getFillerOffset;
 
 	return viewItem;
 }
@@ -23,21 +25,12 @@ export function createViewListItemElement( writer ) {
 // Implementation of getFillerOffset for view list item element.
 //
 // @returns {Number|null} Block filler offset or `null` if block filler is not needed.
-function getFillerOffset() {
+function _getFillerOffset() {
 	const hasOnlyLists = !this.isEmpty && ( this.getChild( 0 ).name == 'ul' || this.getChild( 0 ).name == 'ol' );
 
 	if ( this.isEmpty || hasOnlyLists ) {
 		return 0;
 	}
 
-	const children = [ ...this.getChildren() ];
-	const lastChild = children[ this.childCount - 1 ];
-
-	// Block filler is required after a `<br>` if it's the last element in its container.
-	// See: https://github.com/ckeditor/ckeditor5/issues/1312#issuecomment-436669045.
-	if ( lastChild && lastChild.is( 'element', 'br' ) ) {
-		return this.childCount;
-	}
-
-	return null;
+	return getFillerOffset.call( this );
 }

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -111,6 +111,15 @@ describe( 'utils', () => {
 					expect( item.getFillerOffset() ).to.equal( 4 );
 				} );
 
+				it( 'ignores the ui elements', () => {
+					const item = createViewListItemElement( writer );
+
+					writer.insert( writer.createPositionAt( item, 0 ), writer.createUIElement( 'span' ) );
+					writer.insert( writer.createPositionAt( item, 1 ), writer.createEmptyElement( 'br' ) );
+
+					expect( item.getFillerOffset() ).to.equal( 2 );
+				} );
+
 				it( 'empty element must be the <br> element', () => {
 					const item = createViewListItemElement( writer );
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -69,6 +69,59 @@ describe( 'utils', () => {
 
 				expect( item.getFillerOffset() ).to.be.null;
 			} );
+
+			// Block filler is required after the `<br>` element if the element is the last child in the container.
+			// See: https://github.com/ckeditor/ckeditor5/issues/1312#issuecomment-436669045.
+			describe( 'for <br> elements in container', () => {
+				it( 'returns offset of the last child which is the <br> element (1)', () => {
+					const item = createViewListItemElement( writer );
+
+					writer.insert( writer.createPositionAt( item, 0 ), writer.createEmptyElement( 'br' ) );
+
+					expect( item.getFillerOffset() ).to.equal( 1 );
+				} );
+
+				it( 'returns offset of the last child which is the <br> element (2)', () => {
+					const item = createViewListItemElement( writer );
+
+					writer.insert( writer.createPositionAt( item, 0 ), writer.createEmptyElement( 'br' ) );
+					writer.insert( writer.createPositionAt( item, 1 ), writer.createEmptyElement( 'br' ) );
+
+					expect( item.getFillerOffset() ).to.equal( 2 );
+				} );
+
+				it( 'always returns the last <br> element in the container', () => {
+					const item = createViewListItemElement( writer );
+
+					writer.insert( writer.createPositionAt( item, 0 ), writer.createText( 'foo' ) );
+					writer.insert( writer.createPositionAt( item, 1 ), writer.createEmptyElement( 'br' ) );
+					writer.insert( writer.createPositionAt( item, 2 ), writer.createEmptyElement( 'br' ) );
+
+					expect( item.getFillerOffset() ).to.equal( 3 );
+				} );
+
+				it( 'works fine with non-empty container with multi <br> elements', () => {
+					const item = createViewListItemElement( writer );
+
+					writer.insert( writer.createPositionAt( item, 0 ), writer.createText( 'foo' ) );
+					writer.insert( writer.createPositionAt( item, 1 ), writer.createEmptyElement( 'br' ) );
+					writer.insert( writer.createPositionAt( item, 2 ), writer.createText( 'bar' ) );
+					writer.insert( writer.createPositionAt( item, 3 ), writer.createEmptyElement( 'br' ) );
+
+					expect( item.getFillerOffset() ).to.equal( 4 );
+				} );
+
+				it( 'empty element must be the <br> element', () => {
+					const item = createViewListItemElement( writer );
+
+					writer.insert(
+						writer.createPositionAt( item, 0 ),
+						writer.createEmptyElement( 'img' )
+					);
+
+					expect( item.getFillerOffset() ).to.be.null;
+				} );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Block filler will be inserted into the list item if its last child is a `<br>` element. Closes ckeditor/ckeditor5#1312.
