### PR TITLE
Set UI buttons as toggleable

### DIFF
--- a/src/listui.js
+++ b/src/listui.js
@@ -49,7 +49,8 @@ export default class ListUI extends Plugin {
 			buttonView.set( {
 				label,
 				icon,
-				tooltip: true
+				tooltip: true,
+				isToggleable: true
 			} );
 
 			// Bind button model to command.

--- a/tests/listui.js
+++ b/tests/listui.js
@@ -41,7 +41,10 @@ describe( 'ListUI', () => {
 
 	it( 'should set up buttons for bulleted list and numbered list', () => {
 		expect( bulletedListButton ).to.be.instanceOf( ButtonView );
+		expect( bulletedListButton.isToggleable ).to.be.true;
+
 		expect( numberedListButton ).to.be.instanceOf( ButtonView );
+		expect( numberedListButton.isToggleable ).to.be.true;
 	} );
 
 	it( 'should execute proper commands when buttons are used', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Set UI buttons as toggleable.

---

### Additional information

Requires: ckeditor/ckeditor5-ui#517
