### PR TITLE
Add tests case to increase CC when splitting inside list.

### DIFF
--- a/tests/listediting.js
+++ b/tests/listediting.js
@@ -3870,7 +3870,8 @@ describe( 'ListEditing', () => {
 			);
 		} );
 
-		it( 'should cover else branch', () => {
+		// https://github.com/ckeditor/ckeditor5-list/issues/126#issuecomment-518206743
+		it( 'should properly handle split of list items with non-standard converters', () => {
 			setModelData( model,
 				'<listItem listType="bulleted" listIndent="0">A[]</listItem>' +
 				'<listItem listType="bulleted" listIndent="1">B</listItem>' +

--- a/tests/listediting.js
+++ b/tests/listediting.js
@@ -3884,7 +3884,7 @@ describe( 'ListEditing', () => {
 			editor.conversion.for( 'upcast' ).add( dispatcher => dispatcher.on( 'element:splitBlock', ( evt, data, conversionApi ) => {
 				conversionApi.consumable.consume( data.viewItem, { name: true } );
 
-				// Use split to allowed parent logic to simulate the "improper" use modelCursor after split (set.
+				// Use split to allowed parent logic to simulate a non-standard use of `modelCursor` after split.
 				const splitBlock = conversionApi.writer.createElement( 'splitBlock' );
 				const splitResult = conversionApi.splitToAllowedParent( splitBlock, data.modelCursor );
 


### PR DESCRIPTION

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Add tests case to increase CC when splitting inside list. Closes ckeditor/ckeditor5#3012.

---

### Additional information

* The else statement in viewToModelListItemChildrenConverter() for
checking conditions after split weren't covered after autoparagraphing.
* This tests does the "improper" way of setting modelCursor when splitting to allowed parent.

