### PR TITLE
Fix various issues with todo list converters

### DIFF
--- a/src/todolistconverters.js
+++ b/src/todolistconverters.js
@@ -9,7 +9,7 @@
 
 /* global document */
 
-import { findInRange, generateLiInUl, injectViewList } from './utils';
+import { generateLiInUl, injectViewList } from './utils';
 import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
 
 /**
@@ -242,8 +242,8 @@ export function modelViewChangeChecked( onCheckedChange ) {
 		const { mapper, writer: viewWriter } = conversionApi;
 		const isChecked = !!data.item.getAttribute( 'todoListChecked' );
 		const viewItem = mapper.toViewElement( data.item );
-		const itemRange = viewWriter.createRangeIn( viewItem );
-		const oldCheckmarkElement = findInRange( itemRange, item => item.is( 'uiElement' ) ? item : false );
+		// Because of m -> v position mapper we can be sure checkbox is always at the beginning.
+		const oldCheckmarkElement = viewItem.getChild( 0 );
 		const newCheckmarkElement = createCheckmarkElement( data.item, viewWriter, isChecked, onCheckedChange );
 
 		viewWriter.insert( viewWriter.createPositionAfter( oldCheckmarkElement ), newCheckmarkElement );

--- a/src/todolistconverters.js
+++ b/src/todolistconverters.js
@@ -60,53 +60,6 @@ export function modelViewInsertion( model, onCheckboxChecked ) {
 }
 
 /**
- * A model-to-view converter for the model `$text` element inside a to-do list item.
- *
- * It takes care of creating text after the {@link module:engine/view/uielement~UIElement checkbox UI element}.
- *
- * It is used by {@link module:engine/controller/editingcontroller~EditingController}.
- *
- * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:insert
- * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the fired event.
- * @param {Object} data Additional information about the change.
- * @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi Conversion interface.
- */
-export function modelViewTextInsertion( view ) {
-	return ( evt, data, conversionApi ) => {
-		const parent = data.range.start.parent;
-
-		if ( parent.name != 'listItem' || parent.getAttribute( 'listType' ) != 'todo' ) {
-			return;
-		}
-
-		if ( !conversionApi.consumable.consume( data.item, 'insert' ) ) {
-			return;
-		}
-
-		const viewWriter = conversionApi.writer;
-		const viewPosition = conversionApi.mapper.toViewPosition( data.range.start );
-		const viewText = viewWriter.createText( data.item.data );
-
-		// Be sure text is created after the UIElement, so if it is a first text node inside a `listItem` element
-		// it has to be moved after the first node in the view list item.
-		//
-		// model: <listItem listtype="todo">[foo]</listItem>
-		// view: <li>^<checkbox/></li> -> <li><checkbox/>foo</li>
-		const textInsertionPosition = viewPosition.offset ? viewPosition : viewPosition.getShiftedBy( 1 );
-
-		const label = findLabel( viewPosition.parent, view );
-
-		if ( label && label.parent !== viewPosition.parent && viewPosition.offset === 0 ) {
-			viewWriter.insert( view.createPositionAfter( label ), viewText );
-
-			return;
-		}
-
-		viewWriter.insert( textInsertionPosition, viewText );
-	};
-}
-
-/**
  * A model-to-view converter for the `listItem` model element insertion.
  *
  * It is used by {@link module:engine/controller/datacontroller~DataController}.
@@ -335,14 +288,12 @@ function createCheckmarkElement( modelItem, viewWriter, isChecked, onChange ) {
 }
 
 // Helper method to find label element inside li.
-function findLabel( viewItem, view ) {
+export function findLabel( viewItem, view ) {
 	const range = view.createRangeIn( viewItem );
 
-	let label;
 	for ( const value of range ) {
 		if ( value.item.is( 'uiElement', 'label' ) ) {
-			label = value.item;
+			return value.item;
 		}
 	}
-	return label;
 }

--- a/src/todolistconverters.js
+++ b/src/todolistconverters.js
@@ -233,7 +233,7 @@ export function dataViewModelCheckmarkInsertion( evt, data, conversionApi ) {
  * @param {Function} onCheckedChange Callback fired after clicking the checkbox UI element.
  * @returns {Function} Returns a conversion callback.
  */
-export function modelViewChangeType( onCheckedChange ) {
+export function modelViewChangeType( onCheckedChange, view ) {
 	return ( evt, data, conversionApi ) => {
 		const viewItem = conversionApi.mapper.toViewElement( data.item );
 		const viewWriter = conversionApi.writer;
@@ -246,7 +246,12 @@ export function modelViewChangeType( onCheckedChange ) {
 			viewWriter.insert( viewWriter.createPositionAt( viewItem, 0 ), checkmarkElement );
 		} else if ( data.attributeOldValue == 'todo' ) {
 			viewWriter.removeClass( 'todo-list', viewItem.parent );
-			viewWriter.remove( viewItem.getChild( 0 ) );
+
+			const label = findLabel( viewItem, view );
+
+			if ( label ) {
+				viewWriter.remove( label );
+			}
 		}
 	};
 }
@@ -320,4 +325,17 @@ function createCheckmarkElement( modelItem, viewWriter, isChecked, onChange ) {
 	}
 
 	return uiElement;
+}
+
+// Helper method to find label element inside li.
+function findLabel( viewItem, view ) {
+	const range = view.createRangeIn( viewItem );
+
+	let label;
+	for ( const value of range ) {
+		if ( value.item.is( 'uiElement', 'label' ) ) {
+			label = value.item;
+		}
+	}
+	return label;
 }

--- a/src/todolistediting.js
+++ b/src/todolistediting.js
@@ -14,13 +14,13 @@ import TodoListCheckCommand from './todolistcheckcommand';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import {
-	modelViewInsertion,
 	dataModelViewInsertion,
 	dataModelViewTextInsertion,
 	dataViewModelCheckmarkInsertion,
+	mapModelToViewZeroOffsetPosition,
 	modelViewChangeChecked,
 	modelViewChangeType,
-	findLabel
+	modelViewInsertion
 } from './todolistconverters';
 
 /**
@@ -82,27 +82,7 @@ export default class TodoListEditing extends Plugin {
 			modelViewChangeChecked( listItem => this._handleCheckmarkChange( listItem ) )
 		);
 
-		// Fix view position on 0 offset.
-		editing.mapper.on( 'modelToViewPosition', ( evt, data ) => {
-			const view = editing.view;
-			const modelPosition = data.modelPosition;
-
-			if ( modelPosition.parent.is( 'listItem' ) && modelPosition.parent.getAttribute( 'listType' ) == 'todo' ) {
-				const viewLi = editing.mapper.toViewElement( data.modelPosition.parent );
-
-				if ( modelPosition.offset === 0 ) {
-					const label = findLabel( viewLi, view );
-
-					if ( label ) {
-						if ( label.nextSibling ) {
-							data.viewPosition = view.createPositionAt( label.nextSibling, 0 );
-						} else {
-							data.viewPosition = view.createPositionAfter( label );
-						}
-					}
-				}
-			}
-		}, { priority: 'low' } );
+		editing.mapper.on( 'modelToViewPosition', mapModelToViewZeroOffsetPosition( editing.view, editing.mapper ) );
 
 		data.upcastDispatcher.on( 'element:input', dataViewModelCheckmarkInsertion, { priority: 'high' } );
 

--- a/src/todolistediting.js
+++ b/src/todolistediting.js
@@ -79,7 +79,7 @@ export default class TodoListEditing extends Plugin {
 
 		editing.downcastDispatcher.on(
 			'attribute:listType:listItem',
-			modelViewChangeType( listItem => this._handleCheckmarkChange( listItem ) )
+			modelViewChangeType( listItem => this._handleCheckmarkChange( listItem ), editing.view )
 		);
 		editing.downcastDispatcher.on(
 			'attribute:todoListChecked:listItem',

--- a/src/todolistediting.js
+++ b/src/todolistediting.js
@@ -73,7 +73,7 @@ export default class TodoListEditing extends Plugin {
 			modelViewInsertion( model, listItem => this._handleCheckmarkChange( listItem ) ),
 			{ priority: 'high' }
 		);
-		editing.downcastDispatcher.on( 'insert:$text', modelViewTextInsertion, { priority: 'high' } );
+		editing.downcastDispatcher.on( 'insert:$text', modelViewTextInsertion( editing.view ), { priority: 'high' } );
 		data.downcastDispatcher.on( 'insert:listItem', dataModelViewInsertion( model ), { priority: 'high' } );
 		data.downcastDispatcher.on( 'insert:$text', dataModelViewTextInsertion, { priority: 'high' } );
 

--- a/src/todolistediting.js
+++ b/src/todolistediting.js
@@ -23,8 +23,6 @@ import {
 	findLabel
 } from './todolistconverters';
 
-import { findInRange } from './utils';
-
 /**
  * The engine of the to-do list feature. It handles creating, editing and removing to-do lists and their items.
  *
@@ -47,7 +45,6 @@ export default class TodoListEditing extends Plugin {
 	init() {
 		const editor = this.editor;
 		const { editing, data, model } = editor;
-		const viewDocument = editing.view.document;
 
 		// Extend schema.
 		model.schema.extend( 'listItem', {
@@ -108,29 +105,6 @@ export default class TodoListEditing extends Plugin {
 		}, { priority: 'low' } );
 
 		data.upcastDispatcher.on( 'element:input', dataViewModelCheckmarkInsertion, { priority: 'high' } );
-
-		// Collect all view nodes that have changed and use it to check if the checkbox UI element is going to
-		// be re-rendered. If yes than view post-fixer should verify view structure.
-		const changedViewNodes = new Set();
-
-		Array.from( viewDocument.roots ).forEach( watchRootForViewChildChanges );
-		this.listenTo( viewDocument.roots, 'add', ( evt, root ) => watchRootForViewChildChanges( root ) );
-
-		function watchRootForViewChildChanges( viewRoot ) {
-			viewRoot.on( 'change:children', ( evt, node ) => changedViewNodes.add( node ) );
-		}
-
-		// Move all uiElements after a checkbox element.
-		viewDocument.registerPostFixer( writer => {
-			const changedCheckmarkElements = getChangedCheckmarkElements( writer, changedViewNodes );
-
-			changedViewNodes.clear();
-
-			return moveUIElementsAfterCheckmark( writer, changedCheckmarkElements );
-		} );
-
-		// Move selection after a checkbox element.
-		viewDocument.registerPostFixer( writer => moveSelectionAfterCheckmark( writer, viewDocument.selection ) );
 
 		// Jump at the end of the previous node on left arrow key press, when selection is after the checkbox.
 		//
@@ -205,71 +179,6 @@ export default class TodoListEditing extends Plugin {
 	}
 }
 
-// Moves all UI elements in the to-do list item after the checkbox element.
-//
-// @private
-// @param {module:engine/view/downcastwriter~DowncastWriter} writer
-// @param {Array.<module:engine/view/uielement~UIElement>} uiElements
-// @returns {Boolean}
-function moveUIElementsAfterCheckmark( writer, uiElements ) {
-	let hasChanged = false;
-
-	for ( const uiElement of uiElements ) {
-		const listItem = findViewListItemAncestor( uiElement );
-		const positionAtListItem = writer.createPositionAt( listItem, 0 );
-		const positionBeforeUiElement = writer.createPositionBefore( uiElement );
-
-		if ( positionAtListItem.isEqual( positionBeforeUiElement ) ) {
-			continue;
-		}
-
-		const range = writer.createRange( positionAtListItem, positionBeforeUiElement );
-
-		for ( const item of Array.from( range.getItems() ) ) {
-			if ( item.is( 'uiElement' ) ) {
-				writer.move( writer.createRangeOn( item ), writer.createPositionAfter( uiElement ) );
-				hasChanged = true;
-			}
-		}
-	}
-
-	return hasChanged;
-}
-
-// Moves the selection in the to-do list item after the checkbox element.
-//
-// @private
-// @param {module:engine/view/downcastwriter~DowncastWriter} writer
-// @param {module:engine/view/documentselection~DocumentSelection} selection
-function moveSelectionAfterCheckmark( writer, selection ) {
-	if ( !selection.isCollapsed ) {
-		return false;
-	}
-
-	const positionToChange = selection.getFirstPosition();
-
-	if ( positionToChange.parent.name != 'li' || !positionToChange.parent.parent.hasClass( 'todo-list' ) ) {
-		return false;
-	}
-
-	const parentEndPosition = writer.createPositionAt( positionToChange.parent, 'end' );
-	const uiElement = findInRange( writer.createRange( positionToChange, parentEndPosition ), item => {
-		return ( item.is( 'uiElement' ) && item.hasClass( 'todo-list__checkmark' ) ) ? item : false;
-	} );
-
-	if ( uiElement && !positionToChange.isAfter( writer.createPositionBefore( uiElement ) ) ) {
-		const boundaries = writer.createRange( writer.createPositionAfter( uiElement ), parentEndPosition );
-		const text = findInRange( boundaries, item => item.is( 'textProxy' ) ? item.textNode : false );
-		const nextPosition = text ? writer.createPositionAt( text, 0 ) : parentEndPosition;
-
-		writer.setSelection( writer.createRange( nextPosition ), { isBackward: selection.isBackward } );
-
-		return true;
-	}
-
-	return false;
-}
-
 // Handles the left arrow key and moves the selection at the end of the previous block element if the selection is just after
 // the checkbox element. In other words, it jumps over the checkbox element when moving the selection to the left.
 //
@@ -293,39 +202,6 @@ function jumpOverCheckmarkOnLeftArrowKeyPress( stopKeyEvent, model ) {
 		if ( newRange ) {
 			stopKeyEvent();
 			model.change( writer => writer.setSelection( newRange ) );
-		}
-	}
-}
-
-// Gets the list of all checkbox elements that are going to be rendered.
-//
-// @private
-// @param {module:engine/view/view~View>} editingView
-// @param {Set.<module:engine/view/element~Element>} changedViewNodes
-// @returns {Array.<module:engine/view/uielement~UIElement>}
-function getChangedCheckmarkElements( editingView, changedViewNodes ) {
-	const elements = [];
-
-	for ( const element of changedViewNodes ) {
-		for ( const item of editingView.createRangeIn( element ).getItems() ) {
-			if ( item.is( 'uiElement' ) && item.hasClass( 'todo-list__checkmark' ) && !elements.includes( item ) && element.document ) {
-				elements.push( item );
-			}
-		}
-	}
-
-	return elements;
-}
-
-// Returns the list item ancestor of a given element.
-//
-// @private
-// @param {module:engine/view/item~Item} item
-// @returns {module:engine/view/element~Element}
-function findViewListItemAncestor( item ) {
-	for ( const parent of item.getAncestors( { parentFirst: true } ) ) {
-		if ( parent.name == 'li' ) {
-			return parent;
 		}
 	}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -216,16 +216,6 @@ export function getSiblingListItem( modelItem, options ) {
 	return null;
 }
 
-export function findInRange( range, comparator ) {
-	for ( const item of range.getItems() ) {
-		const result = comparator( item );
-
-		if ( result ) {
-			return result;
-		}
-	}
-}
-
 /**
  * Helper method for creating a UI button and linking it with an appropriate command.
  *

--- a/tests/manual/todo-list.js
+++ b/tests/manual/todo-list.js
@@ -11,13 +11,13 @@ import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
+import Link from '@ckeditor/ckeditor5-link/src/link';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import List from '../../src/list';
 import TodoList from '../../src/todolist';
-import Link from '../../../ckeditor5-link/src/link';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {

--- a/tests/manual/todo-list.js
+++ b/tests/manual/todo-list.js
@@ -17,12 +17,13 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import List from '../../src/list';
 import TodoList from '../../src/todolist';
+import Link from '../../../ckeditor5-link/src/link';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ Enter, Typing, Heading, Highlight, Table, Bold, Paragraph, Undo, List, TodoList, Clipboard ],
+		plugins: [ Enter, Typing, Heading, Highlight, Table, Bold, Paragraph, Undo, List, TodoList, Clipboard, Link ],
 		toolbar: [
-			'heading', '|', 'bulletedList', 'numberedList', 'todoList', '|', 'bold', 'highlight', 'insertTable', '|', 'undo', 'redo'
+			'heading', '|', 'bulletedList', 'numberedList', 'todoList', '|', 'bold', 'link', 'highlight', 'insertTable', '|', 'undo', 'redo'
 		],
 		table: {
 			contentToolbar: [

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -412,7 +412,7 @@ describe( 'TodoListEditing', () => {
 			expect( getViewData( view ) ).to.equal( '<test class="checked">{}Foo</test>' );
 		} );
 
-		it( 'should move selection after checkmark element to the first text node', () => {
+		it( 'should render selection after checkmark element in the first text node', () => {
 			setModelData( model, '<listItem listType="todo" listIndent="0">Foo</listItem>' );
 
 			expect( getViewData( view ) ).to.equal(
@@ -422,7 +422,7 @@ describe( 'TodoListEditing', () => {
 			);
 		} );
 
-		it( 'should move selection after checkmark element when list item does not contain any text node', () => {
+		it( 'should render selection after checkmark element when list item does not contain any text nodes', () => {
 			setModelData( model, '<listItem listType="todo" listIndent="0">[]</listItem>' );
 
 			expect( getViewData( view ) ).to.equal(
@@ -430,6 +430,63 @@ describe( 'TodoListEditing', () => {
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>[]</li>' +
 				'</ul>'
 			);
+		} );
+
+		it( 'should render marker UIElements after the checkmark element', () => {
+			setModelData( model,
+				'<listItem listType="todo" listIndent="0">[]foo</listItem>' +
+				'<listItem listType="todo" listIndent="0">bar</listItem>'
+			);
+
+			editor.conversion.for( 'downcast' ).markerToElement( {
+				model: 'element1',
+				view: ( data, writer ) => writer.createUIElement( 'element1' )
+			} );
+
+			editor.conversion.for( 'downcast' ).markerToElement( {
+				model: 'element2',
+				view: ( data, writer ) => writer.createUIElement( 'element2' )
+			} );
+
+			editor.conversion.for( 'downcast' ).markerToHighlight( {
+				model: 'highlight',
+				view: { classes: 'highlight' }
+			} );
+			model.change( writer => {
+				writer.addMarker( 'element1', {
+					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
+					usingOperation: false
+				} );
+
+				writer.addMarker( 'element2', {
+					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
+					usingOperation: false
+				} );
+
+				writer.addMarker( 'highlight', {
+					range: writer.createRangeIn( modelRoot.getChild( 0 ) ),
+					usingOperation: false
+				} );
+			} );
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul class="todo-list">' +
+					'<li>' +
+						'<span class="highlight">' +
+							'<label class="todo-list__checkmark" contenteditable="false"></label>' +
+							'<element1></element1>' +
+							'<element2></element2>' +
+							'{}foo' +
+						'</span>' +
+					'</li>' +
+					'<li>' +
+						'<label class="todo-list__checkmark" contenteditable="false"></label>bar' +
+					'</li>' +
+				'</ul>'
+			);
+
+			// CC.
+			editor.execute( 'todoListCheck' );
 		} );
 
 		it( 'should properly handle typing inside text node with attribute', () => {
@@ -792,65 +849,6 @@ describe( 'TodoListEditing', () => {
 			);
 
 			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">[]foo</listItem>' );
-		} );
-	} );
-
-	describe( 'uiElements view post-fixer', () => {
-		it( 'should move all UIElements from before a checkmark after the checkmark element', () => {
-			setModelData( model,
-				'<listItem listType="todo" listIndent="0">[]foo</listItem>' +
-				'<listItem listType="todo" listIndent="0">bar</listItem>'
-			);
-
-			editor.conversion.for( 'downcast' ).markerToElement( {
-				model: 'element1',
-				view: ( data, writer ) => writer.createUIElement( 'element1' )
-			} );
-
-			editor.conversion.for( 'downcast' ).markerToElement( {
-				model: 'element2',
-				view: ( data, writer ) => writer.createUIElement( 'element2' )
-			} );
-
-			editor.conversion.for( 'downcast' ).markerToHighlight( {
-				model: 'highlight',
-				view: { classes: 'highlight' }
-			} );
-			model.change( writer => {
-				writer.addMarker( 'element1', {
-					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
-					usingOperation: false
-				} );
-
-				writer.addMarker( 'element2', {
-					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
-					usingOperation: false
-				} );
-
-				writer.addMarker( 'highlight', {
-					range: writer.createRangeIn( modelRoot.getChild( 0 ) ),
-					usingOperation: false
-				} );
-			} );
-
-			expect( getViewData( view ) ).to.equal(
-				'<ul class="todo-list">' +
-					'<li>' +
-						'<span class="highlight">' +
-							'<label class="todo-list__checkmark" contenteditable="false"></label>' +
-							'<element1></element1>' +
-							'<element2></element2>' +
-							'{}foo' +
-						'</span>' +
-					'</li>' +
-					'<li>' +
-						'<label class="todo-list__checkmark" contenteditable="false"></label>bar' +
-					'</li>' +
-				'</ul>'
-			);
-
-			// CC.
-			editor.execute( 'todoListCheck' );
 		} );
 	} );
 

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -412,6 +412,26 @@ describe( 'TodoListEditing', () => {
 			expect( getViewData( view ) ).to.equal( '<test class="checked">{}Foo</test>' );
 		} );
 
+		it( 'should move selection after checkmark element to the first text node', () => {
+			setModelData( model, '<listItem listType="todo" listIndent="0">Foo</listItem>' );
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul class="todo-list">' +
+					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}Foo</li>' +
+				'</ul>'
+			);
+		} );
+
+		it( 'should move selection after checkmark element when list item does not contain any text node', () => {
+			setModelData( model, '<listItem listType="todo" listIndent="0">[]</listItem>' );
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul class="todo-list">' +
+					'<li><label class="todo-list__checkmark" contenteditable="false"></label>[]</li>' +
+				'</ul>'
+			);
+		} );
+
 		it( 'should properly handle typing inside text node with attribute', () => {
 			setModelData( model, '<listItem listType="todo" listIndent="0"><$text bold="true">[]foo</$text></listItem>' );
 
@@ -424,8 +444,8 @@ describe( 'TodoListEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<ul class="todo-list">' +
 					'<li>' +
-				'<label class="todo-list__checkmark" contenteditable="false"></label>' +
-				'<strong>b{}foo</strong>' +
+						'<label class="todo-list__checkmark" contenteditable="false"></label>' +
+						'<strong>b{}foo</strong>' +
 					'</li>' +
 				'</ul>'
 			);
@@ -445,8 +465,8 @@ describe( 'TodoListEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<ul class="todo-list">' +
 					'<li>' +
-				'<label class="todo-list__checkmark" contenteditable="false"></label>' +
-				'<a href="foo"><strong>b{}foo</strong></a>' +
+						'<label class="todo-list__checkmark" contenteditable="false"></label>' +
+						'<a href="foo"><strong>b{}foo</strong></a>' +
 					'</li>' +
 				'</ul>'
 			);
@@ -772,28 +792,6 @@ describe( 'TodoListEditing', () => {
 			);
 
 			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">[]foo</listItem>' );
-		} );
-	} );
-
-	describe( 'selection view post-fixer', () => {
-		it( 'should move selection after checkmark element to the first text node', () => {
-			setModelData( model, '<listItem listType="todo" listIndent="0">Foo</listItem>' );
-
-			expect( getViewData( view ) ).to.equal(
-				'<ul class="todo-list">' +
-					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}Foo</li>' +
-				'</ul>'
-			);
-		} );
-
-		it( 'should move selection after checkmark element when list item does not contain any text node', () => {
-			setModelData( model, '<listItem listType="todo" listIndent="0">[]</listItem>' );
-
-			expect( getViewData( view ) ).to.equal(
-				'<ul class="todo-list">' +
-					'<li><label class="todo-list__checkmark" contenteditable="false"></label>[]</li>' +
-				'</ul>'
-			);
 		} );
 	} );
 

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -12,6 +12,7 @@ import ListCommand from '../src/listcommand';
 import TodoListCheckCommand from '../src/todolistcheckcommand';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
+import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
@@ -27,7 +28,7 @@ describe( 'TodoListEditing', () => {
 	beforeEach( () => {
 		return VirtualTestEditor
 			.create( {
-				plugins: [ TodoListEditing, Typing, BoldEditing, BlockQuoteEditing ]
+				plugins: [ TodoListEditing, Typing, BoldEditing, BlockQuoteEditing, LinkEditing ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -283,6 +284,42 @@ describe( 'TodoListEditing', () => {
 				'</ul>' +
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>3.0</li>' +
+				'</ul>'
+			);
+		} );
+
+		it( 'should properly convert list type change - inner text with attribute', () => {
+			setModelData( model,
+				'<listItem listType="todo" listIndent="0">1[.0</listItem>' +
+				'<listItem listType="todo" listIndent="0"><$text bold="true">2.0</$text></listItem>' +
+				'<listItem listType="todo" listIndent="0">3.]0</listItem>'
+			);
+
+			editor.execute( 'bulletedList' );
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul>' +
+				'<li>1{.0</li>' +
+				'<li><strong>2.0</strong></li>' +
+				'<li>3.}0</li>' +
+				'</ul>'
+			);
+		} );
+
+		it( 'should properly convert list type change - inner text with many attributes', () => {
+			setModelData( model,
+				'<listItem listType="todo" listIndent="0">1[.0</listItem>' +
+				'<listItem listType="todo" listIndent="0"><$text bold="true" linkHref="foo">2.0</$text></listItem>' +
+				'<listItem listType="todo" listIndent="0">3.]0</listItem>'
+			);
+
+			editor.execute( 'bulletedList' );
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul>' +
+				'<li>1{.0</li>' +
+				'<li><a href="foo"><strong>2.0</strong></a></li>' +
+				'<li>3.}0</li>' +
 				'</ul>'
 			);
 		} );

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -411,6 +411,50 @@ describe( 'TodoListEditing', () => {
 			model.change( writer => writer.setAttribute( 'todoListChecked', true, modelRoot.getChild( 0 ) ) );
 			expect( getViewData( view ) ).to.equal( '<test class="checked">{}Foo</test>' );
 		} );
+
+		it( 'should properly handle typing inside text node with attribute', () => {
+			setModelData( model, '<listItem listType="todo" listIndent="0"><$text bold="true">[]foo</$text></listItem>' );
+
+			editor.execute( 'input', { text: 'b' } );
+
+			expect( getModelData( model ) ).to.equal(
+				'<listItem listIndent="0" listType="todo"><$text bold="true">b[]foo</$text></listItem>'
+			);
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul class="todo-list">' +
+					'<li>' +
+						'<strong>' +
+							'<label class="todo-list__checkmark" contenteditable="false"></label>b{}foo' +
+						'</strong>' +
+					'</li>' +
+				'</ul>'
+			);
+		} );
+
+		it( 'should properly handle typing inside text node with many attributes', () => {
+			setModelData( model,
+				'<listItem listType="todo" listIndent="0"><$text bold="true" linkHref="foo">[]foo</$text></listItem>'
+			);
+
+			editor.execute( 'input', { text: 'b' } );
+
+			expect( getModelData( model ) ).to.equal(
+				'<listItem listIndent="0" listType="todo"><$text bold="true" linkHref="foo">b[]foo</$text></listItem>'
+			);
+
+			expect( getViewData( view ) ).to.equal(
+				'<ul class="todo-list">' +
+					'<li>' +
+						'<a class="ck-link_selected" href="foo">' +
+							'<strong>' +
+								'<label class="todo-list__checkmark" contenteditable="false"></label>b{}foo' +
+							'</strong>' +
+						'</a>' +
+					'</li>' +
+				'</ul>'
+			);
+		} );
 	} );
 
 	describe( 'data pipeline m -> v', () => {

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -23,7 +23,7 @@ import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils'
 
 /* global Event, document */
 
-describe.only( 'TodoListEditing', () => {
+describe( 'TodoListEditing', () => {
 	let editor, model, modelDoc, modelRoot, view, viewDoc;
 
 	beforeEach( () => {
@@ -455,12 +455,12 @@ describe.only( 'TodoListEditing', () => {
 			} );
 			model.change( writer => {
 				writer.addMarker( 'element1', {
-					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
+					range: writer.createRange( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
 					usingOperation: false
 				} );
 
 				writer.addMarker( 'element2', {
-					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
+					range: writer.createRange( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),
 					usingOperation: false
 				} );
 
@@ -473,11 +473,11 @@ describe.only( 'TodoListEditing', () => {
 			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li>' +
-						'<span class="highlight">' +
-							'<label class="todo-list__checkmark" contenteditable="false"></label>' +
-							'<element1></element1>' +
+						'<label class="todo-list__checkmark" contenteditable="false"></label>' +
+						'[]<span class="highlight">' +
 							'<element2></element2>' +
-							'{}foo' +
+							'<element1></element1>' +
+							'foo' +
 						'</span>' +
 					'</li>' +
 					'<li>' +

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -19,10 +19,11 @@ import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictest
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 /* global Event, document */
 
-describe( 'TodoListEditing', () => {
+describe.only( 'TodoListEditing', () => {
 	let editor, model, modelDoc, modelRoot, view, viewDoc;
 
 	beforeEach( () => {
@@ -78,13 +79,13 @@ describe( 'TodoListEditing', () => {
 		} );
 
 		it( 'should create to-do list item and change to paragraph in normal usage flow', () => {
-			expect( getViewData( view ) ).to.equal( '<p>[]</p>' );
-			expect( getModelData( model ) ).to.equal( '<paragraph>[]</paragraph>' );
+			assertEqualMarkup( getViewData( view ), '<p>[]</p>' );
+			assertEqualMarkup( getModelData( model ), '<paragraph>[]</paragraph>' );
 
 			editor.execute( 'todoList' );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">[]</listItem>' );
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="todo">[]</listItem>' );
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>[]</li>' +
 				'</ul>'
@@ -92,8 +93,8 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'input', { text: 'a' } );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">a[]</listItem>' );
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="todo">a[]</listItem>' );
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>a{}</li>' +
 				'</ul>'
@@ -101,8 +102,8 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'input', { text: 'b' } );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">ab[]</listItem>' );
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="todo">ab[]</listItem>' );
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>ab{}</li>' +
 				'</ul>'
@@ -110,8 +111,8 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'todoList' );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph>ab[]</paragraph>' );
-			expect( getViewData( view ) ).to.equal( '<p>ab{}</p>' );
+			assertEqualMarkup( getModelData( model ), '<paragraph>ab[]</paragraph>' );
+			assertEqualMarkup( getViewData( view ), '<p>ab{}</p>' );
 		} );
 
 		it( 'should register todoListCheck command', () => {
@@ -126,7 +127,7 @@ describe( 'TodoListEditing', () => {
 				'<listItem listType="todo" listIndent="0" todoListChecked="true">2</listItem>'
 			);
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}1</li>' +
 					'<li><label class="todo-list__checkmark todo-list__checkmark_checked" contenteditable="false"></label>2</li>' +
@@ -144,7 +145,7 @@ describe( 'TodoListEditing', () => {
 				'<listItem listType="todo" listIndent="1">6.1</listItem>'
 			);
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li>' +
 						'<label class="todo-list__checkmark" contenteditable="false"></label>{}1.0' +
@@ -173,7 +174,7 @@ describe( 'TodoListEditing', () => {
 				'<listItem listType="todo" listIndent="1">5.1</listItem>'
 			);
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}1.0</li>' +
 				'</ul>' +
@@ -202,7 +203,7 @@ describe( 'TodoListEditing', () => {
 				'<listItem listType="todo" listIndent="1">5.1</listItem>'
 			);
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}1.0</li>' +
 				'</ul>' +
@@ -231,7 +232,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'todoList' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ol>' +
 					'<li>1.0</li>' +
 				'</ol>' +
@@ -253,7 +254,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'numberedList' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>1.0</li>' +
 				'</ul>' +
@@ -275,7 +276,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'bulletedList' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>1.0</li>' +
 				'</ul>' +
@@ -297,7 +298,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'bulletedList' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul>' +
 				'<li>1{.0</li>' +
 				'<li><strong>2.0</strong></li>' +
@@ -315,7 +316,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'bulletedList' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul>' +
 				'<li>1{.0</li>' +
 				'<li><a href="foo"><strong>2.0</strong></a></li>' +
@@ -327,7 +328,7 @@ describe( 'TodoListEditing', () => {
 		it( 'should convert todoListChecked attribute change', () => {
 			setModelData( model, '<listItem listType="todo" listIndent="0">1.0</listItem>' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}1.0</li>' +
 				'</ul>'
@@ -337,7 +338,7 @@ describe( 'TodoListEditing', () => {
 				writer.setAttribute( 'todoListChecked', true, modelRoot.getChild( 0 ) );
 			} );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark todo-list__checkmark_checked" contenteditable="false"></label>{}1.0</li>' +
 				'</ul>'
@@ -347,7 +348,7 @@ describe( 'TodoListEditing', () => {
 				writer.setAttribute( 'todoListChecked', false, modelRoot.getChild( 0 ) );
 			} );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}1.0</li>' +
 				'</ul>'
@@ -362,7 +363,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'bulletedList' );
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="bulleted">f[oo</listItem>' +
 				'<listItem listIndent="0" listType="bulleted">fo]o</listItem>'
 			);
@@ -406,16 +407,16 @@ describe( 'TodoListEditing', () => {
 			}, { priority: 'highest' } );
 
 			setModelData( model, '<listItem listType="todo" listIndent="0">Foo</listItem>' );
-			expect( getViewData( view ) ).to.equal( '<test>{}Foo</test>' );
+			assertEqualMarkup( getViewData( view ), '<test>{}Foo</test>' );
 
 			model.change( writer => writer.setAttribute( 'todoListChecked', true, modelRoot.getChild( 0 ) ) );
-			expect( getViewData( view ) ).to.equal( '<test class="checked">{}Foo</test>' );
+			assertEqualMarkup( getViewData( view ), '<test class="checked">{}Foo</test>' );
 		} );
 
 		it( 'should render selection after checkmark element in the first text node', () => {
 			setModelData( model, '<listItem listType="todo" listIndent="0">Foo</listItem>' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>{}Foo</li>' +
 				'</ul>'
@@ -425,7 +426,7 @@ describe( 'TodoListEditing', () => {
 		it( 'should render selection after checkmark element when list item does not contain any text nodes', () => {
 			setModelData( model, '<listItem listType="todo" listIndent="0">[]</listItem>' );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li><label class="todo-list__checkmark" contenteditable="false"></label>[]</li>' +
 				'</ul>'
@@ -469,7 +470,7 @@ describe( 'TodoListEditing', () => {
 				} );
 			} );
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li>' +
 						'<span class="highlight">' +
@@ -494,11 +495,11 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'input', { text: 'b' } );
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="todo"><$text bold="true">b[]foo</$text></listItem>'
 			);
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li>' +
 						'<label class="todo-list__checkmark" contenteditable="false"></label>' +
@@ -515,11 +516,11 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'input', { text: 'b' } );
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="todo"><$text bold="true" linkHref="foo">b[]foo</$text></listItem>'
 			);
 
-			expect( getViewData( view ) ).to.equal(
+			assertEqualMarkup( getViewData( view ),
 				'<ul class="todo-list">' +
 					'<li>' +
 						'<label class="todo-list__checkmark" contenteditable="false"></label>' +
@@ -702,7 +703,7 @@ describe( 'TodoListEditing', () => {
 		it( 'should convert li with checkbox before the first text node as to-do list item', () => {
 			editor.setData( '<ul><li><input type="checkbox">foo</li></ul>' );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">[]foo</listItem>' );
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="todo">[]foo</listItem>' );
 		} );
 
 		it( 'should convert li with checked checkbox as checked to-do list item', () => {
@@ -714,7 +715,7 @@ describe( 'TodoListEditing', () => {
 				'</ul>'
 			);
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="todo" todoListChecked="true">[]a</listItem>' +
 				'<listItem listIndent="0" listType="todo" todoListChecked="true">b</listItem>' +
 				'<listItem listIndent="0" listType="todo" todoListChecked="true">c</listItem>'
@@ -724,13 +725,13 @@ describe( 'TodoListEditing', () => {
 		it( 'should not convert li with checkbox in the middle of the text', () => {
 			editor.setData( '<ul><li>Foo<input type="checkbox">Bar</li></ul>' );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">[]FooBar</listItem>' );
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="bulleted">[]FooBar</listItem>' );
 		} );
 
 		it( 'should convert li with checkbox wrapped by inline elements when checkbox is before the first text node', () => {
 			editor.setData( '<ul><li><label><input type="checkbox">Foo</label></li></ul>' );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">[]Foo</listItem>' );
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="todo">[]Foo</listItem>' );
 		} );
 
 		it( 'should split items with checkboxes - bulleted list', () => {
@@ -742,7 +743,7 @@ describe( 'TodoListEditing', () => {
 				'</ul>'
 			);
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="bulleted">[]foo</listItem>' +
 				'<listItem listIndent="0" listType="todo">bar</listItem>' +
 				'<listItem listIndent="0" listType="bulleted">biz</listItem>'
@@ -758,7 +759,7 @@ describe( 'TodoListEditing', () => {
 				'</ol>'
 			);
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="numbered">[]foo</listItem>' +
 				'<listItem listIndent="0" listType="todo">bar</listItem>' +
 				'<listItem listIndent="0" listType="numbered">biz</listItem>'
@@ -784,7 +785,7 @@ describe( 'TodoListEditing', () => {
 				'</ul>'
 			);
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="bulleted">[]1.1</listItem>' +
 				'<listItem listIndent="1" listType="todo">2.2</listItem>' +
 				'<listItem listIndent="1" listType="todo">3.2</listItem>' +
@@ -827,7 +828,7 @@ describe( 'TodoListEditing', () => {
 				'</ul>'
 			);
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<listItem listIndent="0" listType="todo" todoListChecked="true">[]1.1</listItem>' +
 				'<listItem listIndent="1" listType="todo">2.2</listItem>' +
 				'<listItem listIndent="1" listType="todo" todoListChecked="true">3.2</listItem>' +
@@ -848,7 +849,7 @@ describe( 'TodoListEditing', () => {
 				'</ul>'
 			);
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">[]foo</listItem>' );
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="numbered">[]foo</listItem>' );
 		} );
 	} );
 
@@ -858,7 +859,7 @@ describe( 'TodoListEditing', () => {
 
 			editor.execute( 'todoList' );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph>fo[]o</paragraph>' );
+			assertEqualMarkup( getModelData( model ), '<paragraph>fo[]o</paragraph>' );
 		} );
 	} );
 
@@ -888,7 +889,7 @@ describe( 'TodoListEditing', () => {
 
 			viewDoc.fire( 'keydown', domEvtDataStub );
 
-			expect( getModelData( model ) ).to.equal(
+			assertEqualMarkup( getModelData( model ),
 				'<blockQuote><paragraph>foo[]</paragraph></blockQuote>' +
 				'<listItem listIndent="0" listType="todo">bar</listItem>'
 			);
@@ -905,7 +906,7 @@ describe( 'TodoListEditing', () => {
 			sinon.assert.notCalled( domEvtDataStub.preventDefault );
 			sinon.assert.notCalled( domEvtDataStub.stopPropagation );
 
-			expect( getModelData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">[]bar</listItem>' );
+			assertEqualMarkup( getModelData( model ), '<listItem listIndent="0" listType="todo">[]bar</listItem>' );
 		} );
 
 		it( 'should do nothing when selection is not collapsed', () => {
@@ -1032,7 +1033,7 @@ describe( 'TodoListEditing', () => {
 
 		sinon.assert.calledOnce( command.execute );
 		expect( checkboxElement.checked ).to.equal( true );
-		expect( getModelData( model ) ).to.equal(
+		assertEqualMarkup( getModelData( model ),
 			'<listItem listIndent="0" listType="todo" todoListChecked="true">foo</listItem>' +
 			'<paragraph>b[a]r</paragraph>'
 		);
@@ -1045,7 +1046,7 @@ describe( 'TodoListEditing', () => {
 
 		sinon.assert.calledTwice( command.execute );
 		expect( checkboxElement.checked ).to.equal( false );
-		expect( getModelData( model ) ).to.equal(
+		assertEqualMarkup( getModelData( model ),
 			'<listItem listIndent="0" listType="todo">foo</listItem>' +
 			'<paragraph>b[a]r</paragraph>'
 		);
@@ -1073,7 +1074,7 @@ describe( 'TodoListEditing', () => {
 
 		sinon.assert.calledOnce( command.execute );
 		expect( checkboxElement.checked ).to.equal( true );
-		expect( getModelData( model ) ).to.equal(
+		assertEqualMarkup( getModelData( model ),
 			'<listItem listIndent="0" listType="todo" todoListChecked="true">f[]oo</listItem>'
 		);
 	} );

--- a/tests/todolistediting.js
+++ b/tests/todolistediting.js
@@ -424,9 +424,8 @@ describe( 'TodoListEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<ul class="todo-list">' +
 					'<li>' +
-						'<strong>' +
-							'<label class="todo-list__checkmark" contenteditable="false"></label>b{}foo' +
-						'</strong>' +
+				'<label class="todo-list__checkmark" contenteditable="false"></label>' +
+				'<strong>b{}foo</strong>' +
 					'</li>' +
 				'</ul>'
 			);
@@ -446,11 +445,8 @@ describe( 'TodoListEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<ul class="todo-list">' +
 					'<li>' +
-						'<a class="ck-link_selected" href="foo">' +
-							'<strong>' +
-								'<label class="todo-list__checkmark" contenteditable="false"></label>b{}foo' +
-							'</strong>' +
-						'</a>' +
+				'<label class="todo-list__checkmark" contenteditable="false"></label>' +
+				'<a href="foo"><strong>b{}foo</strong></a>' +
 					'</li>' +
 				'</ul>'
 			);
@@ -822,7 +818,6 @@ describe( 'TodoListEditing', () => {
 				model: 'highlight',
 				view: { classes: 'highlight' }
 			} );
-
 			model.change( writer => {
 				writer.addMarker( 'element1', {
 					range: writer.createRangeIn( writer.createPositionAt( modelRoot.getChild( 0 ), 0 ) ),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Use model-to-view position mapping in todo list. Closes ckeditor/ckeditor5#2009. Closed ckeditor/ckeditor5#1980.

The todo list converters always assumed that checkbox ui element is the first child
of a list item in the view. This failed with attribute element converters which wrapped
whole list item contents, including the checkbox, with their attribute element
(e.g. `<strong>`). This changed the first child of the list item and caused problem
with typing or changing list type in the editing area. This change makes sure that
position at the begining of a list item from model is mapped after the checkbox
ui element in the view.


---

### Additional information

- This PR fixes the issues with a todo list described in orignal issue ckeditor/ckeditor5#2009 and others found by me during the work on this PR which revolved around the issues described above.

---

#### Notes from draft PR

* This is a draft PR - fixing some issues with todo lists that involve typing and list modifications when the list item contains a text node with attributes.
* after some fiddling I gather that the easiest fix would be to fix the model to view position mapper, unfortunately, it breaks the test for the markers.

So I have some questions about this: todo list + markers - why the previous solution didn't just map the positions? Is it because of the markers? After my change, you cannot create a highlight that covers the whole `<li>` - it will be set after the checkbox.

Fixing position mapping in helps with:
- typing at the first position when the text has one or more attributes
- the same situation but instead of typing you press <kbd>enter</kbd> - then some view element leftovers appear and the arrow movement was broken
- original issue when changing list type and one todo item has a text attribute

The problem for the above wast that the converters assumed that the first child was always a `label` for the checkbox but with the text attributes (bold, link) the associated view element was wrapping the `li` contents and the ui element (label). Fixing the position mapping so the view position is always set after the ui element keeps the ui element as the first child and other converters also properly render their view (ie only wraps the text of the `li` excluding the UI element.

/cc @oskarwrobel - with a question about the implementation - maybe I'm missing something
/cc @scofalik How this should work with the markers?  Or this should the markes be rendered differently on a todo item?
