### PR TITLE
t/ckeditor5/2090: To-do list item styles should not be interactive when applied to edit…

### DIFF
--- a/theme/todolist.css
+++ b/theme/todolist.css
@@ -7,6 +7,10 @@
 	--ck-todo-list-checkmark-size: 16px;
 }
 
+/*
+ * To-do list should be interactive only during the editing
+ * (https://github.com/ckeditor/ckeditor5/issues/2090).
+ */
 .ck-editor__editable .todo-list {
 	& .todo-list__label {
 		& > input {

--- a/theme/todolist.css
+++ b/theme/todolist.css
@@ -7,6 +7,18 @@
 	--ck-todo-list-checkmark-size: 16px;
 }
 
+.ck-editor__editable .todo-list {
+	& .todo-list__label {
+		& > input {
+			cursor: pointer;
+
+			&:hover::before {
+				box-shadow: 0 0 0 5px hsla(0, 0%, 0%, 0.1);
+			}
+		}
+	}
+}
+
 .ck-content .todo-list {
 	list-style: none;
 
@@ -23,7 +35,6 @@
 			-webkit-appearance: none;
 			display: inline-block;
 			position: relative;
-			cursor: pointer;
 			width: var(--ck-todo-list-checkmark-size);
 			height: var(--ck-todo-list-checkmark-size);
 			vertical-align: middle;
@@ -65,10 +76,6 @@
 				border-color: transparent;
 				border-width: 0 calc( var(--ck-todo-list-checkmark-size) / 8 ) calc( var(--ck-todo-list-checkmark-size) / 8 ) 0;
 				transform: rotate(45deg);
-			}
-
-			&:hover::before {
-				box-shadow: 0 0 0 5px hsla(0, 0%, 0%, 0.1);
 			}
 
 			&[checked] {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: To-do list item styles should not be interactive when applied to editor data (content). Closes ckeditor/ckeditor5#2090.
