### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -241,7 +241,10 @@ export function createUIComponent( editor, commandName, label, icon ) {
 		buttonView.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 
 		// Execute command.
-		buttonView.on( 'execute', () => editor.execute( commandName ) );
+		buttonView.on( 'execute', () => {
+			editor.execute( commandName );
+			editor.editing.view.focus();
+		} );
 
 		return buttonView;
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066