### PR TITLE
Don't access previousSibling that many times to optimize long lists processing

### DIFF
--- a/src/converters.js
+++ b/src/converters.js
@@ -649,30 +649,34 @@ export function modelChangePostFixer( model, writer ) {
 	return applied;
 
 	function _addListToFix( position ) {
-		const prev = position.nodeBefore;
+		const previousNode = position.nodeBefore;
 
-		if ( !prev || !prev.is( 'listItem' ) ) {
+		if ( !previousNode || !previousNode.is( 'listItem' ) ) {
 			const item = position.nodeAfter;
 
 			if ( item && item.is( 'listItem' ) ) {
 				itemToListHead.set( item, item );
 			}
 		} else {
-			let listHead = prev;
+			let listHead = previousNode;
 
 			if ( itemToListHead.has( listHead ) ) {
 				return;
 			}
 
-			while ( listHead.previousSibling && listHead.previousSibling.is( 'listItem' ) ) {
-				listHead = listHead.previousSibling;
+			for (
+				let previousSibling = listHead.previousSibling;
+				previousSibling && previousSibling.is( 'listItem' );
+				previousSibling = listHead.previousSibling
+			) {
+				listHead = previousSibling;
 
 				if ( itemToListHead.has( listHead ) ) {
 					return;
 				}
 			}
 
-			itemToListHead.set( position.nodeBefore, listHead );
+			itemToListHead.set( previousNode, listHead );
 		}
 	}
 

--- a/src/converters.js
+++ b/src/converters.js
@@ -665,6 +665,7 @@ export function modelChangePostFixer( model, writer ) {
 			}
 
 			for (
+				// Cache previousSibling and reuse for performance reasons. See #6581.
 				let previousSibling = listHead.previousSibling;
 				previousSibling && previousSibling.is( 'listItem' );
 				previousSibling = listHead.previousSibling


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Improved performance of processing (loading) long lists. Closes ckeditor/ckeditor5#6581.

---

### Additional information

I'm testing this with "long (semantic)" content of http://localhost:8125/ckeditor5/tests/manual/performance/setdata.html which has a 500 item list, so it's a bit of an edge case, but the improvement is simple and gain is singnificant so I went for it.